### PR TITLE
ci: dont use catalog as source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,5 +13,5 @@ on:
 
 jobs:
   call-terraform-ci-pipeline:
-    uses: terraform-ibm-modules/common-pipeline-assets/.github/workflows/common-terraform-module-ci.yml@v1.3.2
+    uses: terraform-ibm-modules/common-pipeline-assets/.github/workflows/common-terraform-module-ci.yml@v1.4.0
     secrets: inherit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,5 +13,5 @@ on:
 jobs:
   call-terraform-release-pipeline:
     if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') }}
-    uses: terraform-ibm-modules/common-pipeline-assets/.github/workflows/common-release.yml@v1.3.2
+    uses: terraform-ibm-modules/common-pipeline-assets/.github/workflows/common-release.yml@v1.4.0
     secrets: inherit

--- a/.releaserc
+++ b/.releaserc
@@ -12,7 +12,7 @@
       "successCmd": "echo \"SEMVER_VERSION=${nextRelease.version}\" >> $GITHUB_ENV"
     }],
     ["@semantic-release/exec",{
-      "publishCmd": "./ci/run-catalog-onboarding-pipeline.sh terraform-ibm-landing-zone 7df1e4ca-d54c-4fd0-82ce-3d13247308cd 6e3824e7-68a6-4a47-bbbf-2af6e41e7246 v${nextRelease.version} account vsi-quickstart github.com terraform-ibm-modules slz"
+      "publishCmd": "./ci/run-catalog-onboarding-pipeline.sh terraform-ibm-landing-zone 7df1e4ca-d54c-4fd0-82ce-3d13247308cd 6e3824e7-68a6-4a47-bbbf-2af6e41e7246 v${nextRelease.version} account vsi-quickstart github.com terraform-ibm-modules slz false"
     }]
   ]
 }


### PR DESCRIPTION
### Description

- Pass "false" into `run-catalog-onboarding-pipeline.sh` as arg 10 (which is `useCatalogSource`) to force release using default tar.gz file (not catalog refs)
- bump latest git submodule
- bump latest pipeline

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
