### PR TITLE
feat: ibm provider version locked into 1.45.1 for patterns

### DIFF
--- a/examples/basic/version.tf
+++ b/examples/basic/version.tf
@@ -5,7 +5,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.45.0"
+      version = "1.45.1"
     }
   }
 }

--- a/examples/override-example/version.tf
+++ b/examples/override-example/version.tf
@@ -5,7 +5,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.45.0"
+      version = "1.45.1"
     }
   }
 }

--- a/examples/quickstart/version.tf
+++ b/examples/quickstart/version.tf
@@ -5,7 +5,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.45.0"
+      version = "1.45.1"
     }
   }
 }

--- a/patterns/mixed/versions.tf
+++ b/patterns/mixed/versions.tf
@@ -7,7 +7,7 @@ terraform {
     ibm = {
       source = "IBM-Cloud/ibm"
       # Atracker needs to have the v2 API
-      version = ">= 1.45.0"
+      version = "1.45.1"
     }
     external = {
       source  = "hashicorp/external"

--- a/patterns/roks/versions.tf
+++ b/patterns/roks/versions.tf
@@ -7,7 +7,7 @@ terraform {
     ibm = {
       source = "IBM-Cloud/ibm"
       # Atracker needs to have the v2 API
-      version = ">= 1.45.0"
+      version = "1.45.1"
     }
     external = {
       source  = "hashicorp/external"

--- a/patterns/vsi/versions.tf
+++ b/patterns/vsi/versions.tf
@@ -7,7 +7,7 @@ terraform {
     ibm = {
       source = "IBM-Cloud/ibm"
       # Atracker needs to have the v2 API
-      version = ">= 1.45.0"
+      version = "1.45.0"
     }
     external = {
       source  = "hashicorp/external"

--- a/patterns/vsi/versions.tf
+++ b/patterns/vsi/versions.tf
@@ -7,7 +7,7 @@ terraform {
     ibm = {
       source = "IBM-Cloud/ibm"
       # Atracker needs to have the v2 API
-      version = "1.45.0"
+      version = "1.45.1"
     }
     external = {
       source  = "hashicorp/external"


### PR DESCRIPTION
### Description

Lock in ibm provider version to 1.45.1 for the patterns

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [x] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
