### PR TITLE
ci: set override_json_string to "__NOT_SET__" in json template

### DIFF
--- a/patterns/vsi/catalogValidationValues.json.template
+++ b/patterns/vsi/catalogValidationValues.json.template
@@ -1,1 +1,1 @@
-{"ibmcloud_api_key": $VALIDATION_APIKEY, "region": "us-south", "resource_tags": $TAGS, "prefix": $PREFIX}
+{"ibmcloud_api_key": $VALIDATION_APIKEY, "region": "us-south", "resource_tags": $TAGS, "prefix": $PREFIX, "override_json_string": "__NOT_SET__"}


### PR DESCRIPTION
### Description

set `override_json_string` to "__NOT_SET__" in json template

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
