### PR TITLE
docs: update usage to use variation specific url

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -5,7 +5,7 @@
             "label": "QuickStart",
             "name": "quickstart",
             "working_directory": "examples/quickstart",
-            "usage": "module \"landing-zone\" {\n  source           = \"https://cm.globalcatalog.cloud.ibm.com/api/v1-beta/offering/source?archive=tgz\u0026catalogID=7df1e4ca-d54c-4fd0-82ce-3d13247308cd\u0026flavor=quickstart\u0026kind=terraform\u0026name=slz-vpc-with-vsis\u0026version=1.1.3\"\n  ibmcloud_api_key = var.ibmcloud_api_key\n  ssh_public_key   = var.ssh_public_key\n  region           = \"us-south\"\n  prefix           = \"slz\"\n}\n\n",
+            "usage": "module \"landing-zone\" {\n  source           = \"https://cm.globalcatalog.cloud.ibm.com/api/v1-beta/offering/source//examples/quickstart?archive=tgz\u0026catalogID=7df1e4ca-d54c-4fd0-82ce-3d13247308cd\u0026flavor=quickstart\u0026kind=terraform\u0026name=slz-vpc-with-vsis\u0026version=1.7.1\"\n  ibmcloud_api_key = var.ibmcloud_api_key\n  ssh_public_key   = var.ssh_public_key\n  region           = \"us-south\"\n  prefix           = \"slz\"\n}\n\n",
             "compliance": {
                 "controls": [
                 ]
@@ -109,7 +109,7 @@
             "label": "Standard",
             "name": "standard",
             "working_directory": "patterns/vsi",
-            "usage": "module \"landing-zone\" {\n  source           = \"https://cm.globalcatalog.cloud.ibm.com/api/v1-beta/offering/source?archive=tgz\u0026catalogID=7df1e4ca-d54c-4fd0-82ce-3d13247308cd\u0026flavor=standard\u0026kind=terraform\u0026name=slz-vpc-with-vsis\u0026version=1.1.3\"\n  ibmcloud_api_key = var.ibmcloud_api_key\n  ssh_public_key   = var.ssh_public_key\n  region           = \"us-south\"\n  prefix           = \"slz\"\n}\n\n",
+            "usage": "module \"landing-zone\" {\n  source           = \"https://cm.globalcatalog.cloud.ibm.com/api/v1-beta/offering/source//patterns/vsi?archive=tgz\u0026catalogID=7df1e4ca-d54c-4fd0-82ce-3d13247308cd\u0026flavor=standard\u0026kind=terraform\u0026name=slz-vpc-with-vsis\u0026version=1.7.1\"\n  ibmcloud_api_key = var.ibmcloud_api_key\n  ssh_public_key   = var.ssh_public_key\n  region           = \"us-south\"\n  prefix           = \"slz\"\n}\n\n",
             "compliance": {
                 "controls": [
                     {


### PR DESCRIPTION
### Description

Update the usage url that displays in the catalog consumption UI.  The variations use the syntax "//" just before the example directory name and terraform figures it out.

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ x] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
