### PR TITLE
fix: template module deprecated and f5 acl name

### DIFF
--- a/f5_config/main.tf
+++ b/f5_config/main.tf
@@ -55,27 +55,27 @@ EOD
   do_dec1              = var.license_type == "byol" ? chomp(local.do_byol_license) : "null"
   do_dec2              = var.license_type == "regkeypool" ? chomp(local.do_regekypool) : local.do_dec1
   do_local_declaration = var.license_type == "utilitypool" ? chomp(local.do_utilitypool) : local.do_dec2
-  user_data            = templatefile("${path.module}/user_data.yaml",
-  {
-    tmos_admin_password     = var.tmos_admin_password,
-    configsync_interface    = "1.1",
-    hostname                = var.hostname,
-    domain                  = var.domain,
-    default_route_interface = var.default_route_interface == null ? "1.${length(var.secondary_subnets)}" : var.default_route_interface,
-    default_route_gateway   = cidrhost(var.secondary_subnets[length(var.secondary_subnets) - 1].cidr, 1),
-    do_local_declaration    = local.do_local_declaration,
-    do_declaration_url      = var.do_declaration_url,
-    as3_declaration_url     = var.as3_declaration_url,
-    ts_declaration_url      = var.ts_declaration_url,
-    phone_home_url          = var.phone_home_url,
-    tgactive_url            = var.tgactive_url,
-    tgstandby_url           = var.tgstandby_url,
-    tgrefresh_url           = var.tgrefresh_url,
-    template_source         = var.template_source,
-    template_version        = var.template_version,
-    zone                    = var.zone,
-    vpc                     = var.vpc_id,
-    app_id                  = var.app_id
+  user_data = templatefile("${path.module}/user_data.yaml",
+    {
+      tmos_admin_password     = var.tmos_admin_password,
+      configsync_interface    = "1.1",
+      hostname                = var.hostname,
+      domain                  = var.domain,
+      default_route_interface = var.default_route_interface == null ? "1.${length(var.secondary_subnets)}" : var.default_route_interface,
+      default_route_gateway   = cidrhost(var.secondary_subnets[length(var.secondary_subnets) - 1].cidr, 1),
+      do_local_declaration    = local.do_local_declaration,
+      do_declaration_url      = var.do_declaration_url,
+      as3_declaration_url     = var.as3_declaration_url,
+      ts_declaration_url      = var.ts_declaration_url,
+      phone_home_url          = var.phone_home_url,
+      tgactive_url            = var.tgactive_url,
+      tgstandby_url           = var.tgstandby_url,
+      tgrefresh_url           = var.tgrefresh_url,
+      template_source         = var.template_source,
+      template_version        = var.template_version,
+      zone                    = var.zone,
+      vpc                     = var.vpc_id,
+      app_id                  = var.app_id
   })
 }
 

--- a/f5_config/main.tf
+++ b/f5_config/main.tf
@@ -52,35 +52,31 @@ EOD
         reachable: false
         hypervisor: kvm
 EOD
-  template_file        = file("${path.module}/user_data.yaml")
   do_dec1              = var.license_type == "byol" ? chomp(local.do_byol_license) : "null"
   do_dec2              = var.license_type == "regkeypool" ? chomp(local.do_regekypool) : local.do_dec1
   do_local_declaration = var.license_type == "utilitypool" ? chomp(local.do_utilitypool) : local.do_dec2
-}
-
-data "template_file" "user_data" {
-  template = local.template_file
-  vars = {
-    tmos_admin_password     = var.tmos_admin_password
-    configsync_interface    = "1.1"
-    hostname                = var.hostname
-    domain                  = var.domain
-    default_route_interface = var.default_route_interface == null ? "1.${length(var.secondary_subnets)}" : var.default_route_interface
-    default_route_gateway   = cidrhost(var.secondary_subnets[length(var.secondary_subnets) - 1].cidr, 1)
-    do_local_declaration    = local.do_local_declaration
-    do_declaration_url      = var.do_declaration_url
-    as3_declaration_url     = var.as3_declaration_url
-    ts_declaration_url      = var.ts_declaration_url
-    phone_home_url          = var.phone_home_url
-    tgactive_url            = var.tgactive_url
-    tgstandby_url           = var.tgstandby_url
-    tgrefresh_url           = var.tgrefresh_url
-    template_source         = var.template_source
-    template_version        = var.template_version
-    zone                    = var.zone
-    vpc                     = var.vpc_id
+  user_data            = templatefile("${path.module}/user_data.yaml",
+  {
+    tmos_admin_password     = var.tmos_admin_password,
+    configsync_interface    = "1.1",
+    hostname                = var.hostname,
+    domain                  = var.domain,
+    default_route_interface = var.default_route_interface == null ? "1.${length(var.secondary_subnets)}" : var.default_route_interface,
+    default_route_gateway   = cidrhost(var.secondary_subnets[length(var.secondary_subnets) - 1].cidr, 1),
+    do_local_declaration    = local.do_local_declaration,
+    do_declaration_url      = var.do_declaration_url,
+    as3_declaration_url     = var.as3_declaration_url,
+    ts_declaration_url      = var.ts_declaration_url,
+    phone_home_url          = var.phone_home_url,
+    tgactive_url            = var.tgactive_url,
+    tgstandby_url           = var.tgstandby_url,
+    tgrefresh_url           = var.tgrefresh_url,
+    template_source         = var.template_source,
+    template_version        = var.template_version,
+    zone                    = var.zone,
+    vpc                     = var.vpc_id,
     app_id                  = var.app_id
-  }
+  })
 }
 
 

--- a/f5_config/outputs.tf
+++ b/f5_config/outputs.tf
@@ -4,7 +4,7 @@
 
 output "user_data" {
   description = "Cloud Init data for F5 instance"
-  value       = data.template_file.user_data.rendered
+  value       = local.user_data
 }
 
 ##############################################################################

--- a/f5_config/versions.tf
+++ b/f5_config/versions.tf
@@ -3,12 +3,6 @@
 ##############################################################################
 
 terraform {
-  required_providers {
-    template = {
-      source  = "hashicorp/template"
-      version = "2.2.0"
-    }
-  }
   required_version = ">=1.0"
   experiments      = [module_variable_optional_attrs]
 }

--- a/module-metadata.json
+++ b/module-metadata.json
@@ -2381,25 +2381,12 @@
         "teleport_version": "teleport_config_data"
       },
       "managed_resources": {},
-      "data_resources": {
-        "data.template_cloudinit_config.cloud_init": {
-          "mode": "data",
-          "type": "template_cloudinit_config",
-          "name": "cloud_init",
-          "provider": {
-            "name": "template"
-          },
-          "pos": {
-            "filename": "teleport_config/template.tf",
-            "line": 28
-          }
-        }
-      },
+      "data_resources": {},
       "outputs": {
         "cloud_init": {
           "name": "cloud_init",
           "description": "Description of my output",
-          "value": "data.template_cloudinit_config.cloud_init.rendered",
+          "value": "local.user_data",
           "pos": {
             "filename": "teleport_config/outputs.tf",
             "line": 5

--- a/patterns/dynamic_values/config_modules/acl_rules/acl_rules.tf
+++ b/patterns/dynamic_values/config_modules/acl_rules/acl_rules.tf
@@ -56,7 +56,7 @@ output "bastion" {
   ]
 }
 
-output "f5_external" {
+output "f5-external" {
   description = "F5 external allow all"
   value = [
     {

--- a/patterns/dynamic_values/config_modules/network_acls/network_acls.tf
+++ b/patterns/dynamic_values/config_modules/network_acls/network_acls.tf
@@ -51,7 +51,7 @@ output "value" {
       for network_acl in concat(
         [network],
         var.use_teleport && network == var.bastion_vpc_name ? ["bastion"] : [],
-        var.use_f5 && network == var.vpc_list[0] ? ["f5_external"] : []
+        var.use_f5 && network == var.vpc_list[0] ? ["f5-external"] : []
       ) :
       {
         name              = "${network_acl}-acl"

--- a/teleport_config/outputs.tf
+++ b/teleport_config/outputs.tf
@@ -4,7 +4,7 @@
 
 output "cloud_init" {
   description = "Description of my output"
-  value       = data.template_cloudinit_config.cloud_init.rendered
+  value       = local.user_data
 }
 
 ##############################################################################

--- a/teleport_config/template.tf
+++ b/teleport_config/template.tf
@@ -25,12 +25,4 @@ locals {
   )
 }
 
-data "template_cloudinit_config" "cloud_init" {
-  base64_encode = false
-  gzip          = false
-  part {
-    content = local.user_data
-  }
-}
-
 ##############################################################################

--- a/teleport_config/versions.tf
+++ b/teleport_config/versions.tf
@@ -3,12 +3,6 @@
 ##############################################################################
 
 terraform {
-  required_providers {
-    template = {
-      source  = "hashicorp/template"
-      version = "2.2.0"
-    }
-  }
   required_version = ">=1.0"
 }
 

--- a/teleport_config/versions.tf
+++ b/teleport_config/versions.tf
@@ -3,6 +3,12 @@
 ##############################################################################
 
 terraform {
+  required_providers {
+    template = {
+      source  = "hashicorp/template"
+      version = "2.2.0"
+    }
+  }
   required_version = ">=1.0"
 }
 


### PR DESCRIPTION
### Description

template_file is deprecated and does not work with M1 machines.  Move to templatefile

**Check the relevant boxes:**
- [x] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
