### PR TITLE
docs: use absolute links for images

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,7 +880,7 @@ statement instead the previous block.
 - [ VPC landing zone (No compute example)](examples/no-compute-example)
 - [ One VPC with one VSI](examples/one-vpc-one-vsi)
 - [ Override.json example](examples/override-example)
-- [ VSI on VPC landing zone (Quick start example)](examples/quickstart)
+- [ VSI on VPC landing zone (QuickStart example)](examples/quickstart)
 <!-- END EXAMPLES HOOK -->
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/no-compute-example/README.md
+++ b/examples/no-compute-example/README.md
@@ -1,6 +1,7 @@
 # VPC landing zone (No compute example)
 
-![vpc](../../reference-architectures/vpc.drawio.svg)
+![Architecture diagram for the Standard variation of VPC landing zone](https://raw.githubusercontent.com/terraform-ibm-modules/terraform-ibm-landing-zone/main/reference-architectures/vpc.drawio.svg)
 
-- This example shows how you can use the landing zone module to create a networking infrastructure layer without any compute resources (no VSI, nor OpenShift cluster).
-- This example provides a base to a modular solution because you can use this network layer as a base on which the compute resources are deployed, possibly through separate Terraform modules.
+You can use the VPC landing zone example to deploy a simple IBM Cloud VPC infrastructure without any compute resources like Virtual Server Instances (VSIs) or Red Hat OpenShift clusters.
+
+The example is a modular solution because you can use this architecture as a base on which to deploy compute resources. You can also deploy those resources by using the other landing zone deployable architectures or Terraform modules.

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -1,10 +1,10 @@
-# VSI on VPC landing zone (Quick start example)
+# VSI on VPC landing zone (QuickStart example)
 
-![vsi-quickstart](../../reference-architectures/vsi-quickstart.drawio.svg)
+![Architecture diagram for the QuickStart variation of VSI on VPC landing zone](https://raw.githubusercontent.com/terraform-ibm-modules/terraform-ibm-landing-zone/main/reference-architectures/vsi-quickstart.drawio.svg)
 
 This example deploys the following infrastructure:
 
 - An edge VPC with 1 VSI in one of the three subnets and a VPC load balancer in the edge VPC, exposing the VSI publicly.
 - A jump server VSI in the management VPC, exposing a public floating IP address.
 
-:exclamation: **Important:** This example helps you get started quickly, but is not highly available or validated for the IBM Cloud Framework for Financial Services.
+**Important:** This example helps you get started quickly, but is not highly available or validated for the IBM Cloud Framework for Financial Services.

--- a/patterns/roks/README.md
+++ b/patterns/roks/README.md
@@ -1,3 +1,5 @@
 # Red Hat OpenShift Container Platform on VPC landing zone
 
-![roks](../../reference-architectures/roks.drawio.svg)
+![Architecture diagram of the OpenShift Container Platform on VPC deployable architecture](https://raw.githubusercontent.com/terraform-ibm-modules/terraform-ibm-landing-zone/main/reference-architectures/roks.drawio.svg)
+
+This architecture supports the creation of a Red Hat OpenShift Container Platform on VPC landing zone in a single region architecture on IBM Cloud.

--- a/patterns/vsi/README.md
+++ b/patterns/vsi/README.md
@@ -1,5 +1,5 @@
 # VSI on VPC landing zone
 
-This template allows a user to create a landing zone
+![Architecture diagram for the Standard variation of VSI on VPC landing zone](https://raw.githubusercontent.com/terraform-ibm-modules/terraform-ibm-landing-zone/main/reference-architectures/vsi-vsi.drawio.svg)
 
-![vsi](../../reference-architectures/vsi-vsi.drawio.svg)
+This architecture supports the creation of a VSI on VPC landing zone on IBM Cloud.


### PR DESCRIPTION
### Description

- Changing the image URLs for the readme files that are pulled in the IBM Cloud catalog. Relative links produce broken images there.
- Updating text to provide a bit more information in the context of the catalog details.

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [x] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [ ] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Replace this text with information that users need to know about the bug fixes, features, and breaking changes. This information helps the merger write the commit message that is published in the release notes for the module.

---

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
