### PR TITLE
fix: set ssh_keys to empty list in pvc pattern override json

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-04-06T14:59:53Z",
+  "generated_at": "2023-04-12T18:47:14Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "83b1c425484475e97934007eccb2277e9bdbd203",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 1135,
+        "line_number": 1336,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/examples/no-compute-example/catalogValidationValues.json.template
+++ b/examples/no-compute-example/catalogValidationValues.json.template
@@ -1,1 +1,0 @@
-{"ibmcloud_api_key": $VALIDATION_APIKEY, "region": "us-south", "resource_tags": $TAGS, "prefix": $PREFIX}

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -786,8 +786,8 @@
                     "label": "Standard",
                     "name": "standard",
                     "install_type": "fullstack",
-                    "working_directory": "examples/no-compute-example",
-                    "usage_template": "module \"landing-zone-vpc\" {\n  source           = \"https://cm.globalcatalog.cloud.ibm.com/api/v1-beta/offering/source//${{workingDirectory}}?archive=tgz&flavor=${{flavor}}&kind=terraform&name=${{name}}&version=${{version}}\"\n  ibmcloud_api_key = var.ibmcloud_api_key\n  ssh_public_key   = var.ssh_public_key\n  region           = \"us-south\"\n  prefix           = \"slz-vpc\"\n}\n\n",
+                    "working_directory": "patterns/vpc",
+                    "usage_template": "module \"landing-zone-vpc\" {\n  source           = \"https://cm.globalcatalog.cloud.ibm.com/api/v1-beta/offering/source//${{workingDirectory}}?archive=tgz&flavor=${{flavor}}&kind=terraform&name=${{name}}&version=${{version}}\"\n  ibmcloud_api_key = var.ibmcloud_api_key\n  region           = \"us-south\"\n  prefix           = \"slz-vpc\"\n}\n\n",
                     "compliance": {
                         "controls": [
                             {
@@ -974,13 +974,6 @@
                     },
                     "configuration": [
                         {
-                            "key": "ssh_key",
-                            "required": true
-                        },
-                        {
-                            "key": "resource_tags"
-                        },
-                        {
                             "key": "ibmcloud_api_key",
                             "required": true,
                             "type": "password"
@@ -1000,6 +993,214 @@
                             },
                             "key": "region",
                             "required": true
+                        },
+                        {
+                            "key": "hs_crypto_instance_name",
+                            "hidden": true
+                        },
+                        {
+                            "key": "create_f5_network_on_management_vpc",
+                            "hidden": true
+                        },
+                        {
+                            "key": "provision_teleport_in_f5",
+                            "hidden": true
+                        },
+                        {
+                            "key": "vpn_firewall_type",
+                            "hidden": true
+                        },
+                        {
+                            "key": "ssh_public_key",
+                            "hidden": true
+                        },
+                        {
+                            "key": "f5_image_name",
+                            "hidden": true
+                        },
+                        {
+                            "key": "f5_instance_profile",
+                            "hidden": true
+                        },
+                        {
+                            "key": "hostname",
+                            "hidden": true
+                        },
+                        {
+                            "key": "domain",
+                            "hidden": true
+                        },
+                        {
+                            "key": "tmos_admin_password",
+                            "hidden": true
+                        },
+                        {
+                            "key": "license_type",
+                            "hidden": true
+                        },
+                        {
+                            "key": "byol_license_basekey",
+                            "hidden": true
+                        },
+                        {
+                            "key": "license_host",
+                            "hidden": true
+                        },
+                        {
+                            "key": "license_username",
+                            "hidden": true
+                        },
+                        {
+                            "key": "license_password",
+                            "hidden": true
+                        },
+                        {
+                            "key": "license_pool",
+                            "hidden": true
+                        },
+                        {
+                            "key": "license_sku_keyword_1",
+                            "hidden": true
+                        },
+                        {
+                            "key": "license_sku_keyword_2",
+                            "hidden": true
+                        },
+                        {
+                            "key": "license_unit_of_measure",
+                            "hidden": true
+                        },
+                        {
+                            "key": "do_declaration_url",
+                            "hidden": true
+                        },
+                        {
+                            "key": "as3_declaration_url",
+                            "hidden": true
+                        },
+                        {
+                            "key": "ts_declaration_url",
+                            "hidden": true
+                        },
+                        {
+                            "key": "phone_home_url",
+                            "hidden": true
+                        },
+                        {
+                            "key": "template_source",
+                            "hidden": true
+                        },
+                        {
+                            "key": "template_version",
+                            "hidden": true
+                        },
+                        {
+                            "key": "app_id",
+                            "hidden": true
+                        },
+                        {
+                            "key": "tgactive_url",
+                            "hidden": true
+                        },
+                        {
+                            "key": "tgstandby_url",
+                            "hidden": true
+                        },
+                        {
+                            "key": "tgrefresh_url",
+                            "hidden": true
+                        },
+                        {
+                            "key": "enable_f5_management_fip",
+                            "hidden": true
+                        },
+                        {
+                            "key": "enable_f5_external_fip",
+                            "hidden": true
+                        },
+                        {
+                            "key": "use_existing_appid",
+                            "hidden": true
+                        },
+                        {
+                            "key": "appid_name",
+                            "hidden": true
+                        },
+                        {
+                            "key": "appid_resource_group",
+                            "hidden": true
+                        },
+                        {
+                            "key": "teleport_instance_profile",
+                            "hidden": true
+                        },
+                        {
+                            "key": "teleport_vsi_image_name",
+                            "hidden": true
+                        },
+                        {
+                            "key": "teleport_license",
+                            "hidden": true
+                        },
+                        {
+                            "key": "https_cert",
+                            "hidden": true
+                        },
+                        {
+                            "key": "https_key",
+                            "hidden": true
+                        },
+                        {
+                            "key": "teleport_hostname",
+                            "hidden": true
+                        },
+                        {
+                            "key": "teleport_domain",
+                            "hidden": true
+                        },
+                        {
+                            "key": "teleport_version",
+                            "hidden": true
+                        },
+                        {
+                            "key": "message_of_the_day",
+                            "hidden": true
+                        },
+                        {
+                            "key": "teleport_admin_email",
+                            "hidden": true
+                        },
+                        {
+                            "key": "create_secrets_manager",
+                            "hidden": true
+                        },
+                        {
+                            "key": "enable_scc",
+                            "hidden": true
+                        },
+                        {
+                            "key": "scc_cred_name",
+                            "hidden": true
+                        },
+                        {
+                            "key": "scc_cred_description",
+                            "hidden": true
+                        },
+                        {
+                            "key": "scc_collector_description",
+                            "hidden": true
+                        },
+                        {
+                            "key": "scc_scope_description",
+                            "hidden": true
+                        },
+                        {
+                            "key": "scc_scope_name",
+                            "hidden": true
+                        },
+                        {
+                            "key": "override",
+                            "hidden": true
                         }
                     ],
                     "iam_permissions": [

--- a/patterns/vpc/catalogValidationValues.json.template
+++ b/patterns/vpc/catalogValidationValues.json.template
@@ -1,1 +1,1 @@
-{"ibmcloud_api_key": $VALIDATION_APIKEY, "region": "us-south", "resource_tags": $TAGS, "prefix": $PREFIX}
+{"ibmcloud_api_key": $VALIDATION_APIKEY, "region": "us-south", "tags": $TAGS, "prefix": $PREFIX}

--- a/patterns/vpc/override.json
+++ b/patterns/vpc/override.json
@@ -99,12 +99,7 @@
   },
   "security_groups": [],
   "service_endpoints": "private",
-  "ssh_keys": [
-      {
-          "name": "slz-ssh-key",
-          "public_key": "<user ssh key value>"
-      }
-  ],
+  "ssh_keys": [],
   "transit_gateway_connections": [
       "management",
       "workload"


### PR DESCRIPTION
### Description

- set ssh_keys to empty list in pvc pattern override json
- update `ibm_catalog.json` to use `patterns/vpc`
- added the variables to hide for VPC pattern in `ibm_catalog.json`
- fix the values in `patterns/vpc/catalogValidationValues.json.template`
- deleted `examples/no-compute-example/catalogValidationValues.json.template`

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [ ] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Replace this text with information that users need to know about the bug fixes, features, and breaking changes. This information helps the merger write the commit message that is published in the release notes for the module.

---

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
