### PR TITLE
fix: remove duplicate substring from policy name

### DIFF
--- a/dynamic_values/config_modules/service_authorizations/service_authorizations.tf
+++ b/dynamic_values/config_modules/service_authorizations/service_authorizations.tf
@@ -82,7 +82,7 @@ module "flow_logs_to_cos" {
   list = [
     for instance in var.cos :
     {
-      name                        = "flow-logs-${instance.name}-cos"
+      name                        = "flow-logs-${instance.name}"
       source_service_name         = "is"
       source_resource_type        = "flow-log-collector"
       description                 = "Allow flow logs write access cloud object storage instance"

--- a/moved_config.tf
+++ b/moved_config.tf
@@ -12,3 +12,13 @@ moved {
   from = ibm_is_flow_log.flow_logs["workload"]
   to   = module.vpc["workload"].ibm_is_flow_log.flow_logs[0]
 }
+
+moved {
+  from = ibm_iam_authorization_policy.policy["flow-logs-atracker-cos-cos"]
+  to   = ibm_iam_authorization_policy.policy["flow-logs-atracker-cos"]
+}
+
+moved {
+  from = ibm_iam_authorization_policy.policy["flow-logs-cos-cos"]
+  to   = ibm_iam_authorization_policy.policy["flow-logs-cos"]
+}


### PR DESCRIPTION
### Description

Plan shows the following:
module.landing_zone.ibm_iam_authorization_policy.policy["flow-logs-atracker-cos-cos"] will be created

Removed the duplicate string `-cos` from the policy name

Issue : https://github.com/terraform-ibm-modules/terraform-ibm-landing-zone/issues/412

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [x] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Removed the duplicate substring `-cos` from the policy name

---

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
