### PR TITLE
ci: set catalog validation for roks DA to use us-south

### DIFF
--- a/patterns/roks/catalogValidationValues.json.template
+++ b/patterns/roks/catalogValidationValues.json.template
@@ -1,1 +1,1 @@
-{"ibmcloud_api_key": $VALIDATION_APIKEY, "region": "eu-gb", "entitlement": "cloud_pak", "tags": $TAGS, "prefix": $PREFIX}
+{"ibmcloud_api_key": $VALIDATION_APIKEY, "region": "us-south", "entitlement": "cloud_pak", "tags": $TAGS, "prefix": $PREFIX}


### PR DESCRIPTION
### Description

Looks like cost generator tool is broken for eu-gb, as it shows 0 cost for OCP:
![image](https://user-images.githubusercontent.com/29608224/234337314-1617914a-3b1a-4ed5-a5a0-8cf0f024eb30.png)


### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [x] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [ ] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Replace this text with information that users need to know about the bug fixes, features, and breaking changes. This information helps the merger write the commit message that is published in the release notes for the module.

---

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
