### PR TITLE
Revert "ci: set catalog validation for roks DA to use us-south"

### DIFF
--- a/patterns/roks/catalogValidationValues.json.template
+++ b/patterns/roks/catalogValidationValues.json.template
@@ -1,1 +1,1 @@
-{"ibmcloud_api_key": $VALIDATION_APIKEY, "region": "us-south", "entitlement": "cloud_pak", "tags": $TAGS, "prefix": $PREFIX}
+{"ibmcloud_api_key": $VALIDATION_APIKEY, "region": "eu-gb", "entitlement": "cloud_pak", "tags": $TAGS, "prefix": $PREFIX}


### PR DESCRIPTION
Reverts terraform-ibm-modules/terraform-ibm-landing-zone#421

The issue is resolved, so setting back to use `eu-gb` to ensure we don't hit transit gateway quotas in us-south