### PR TITLE
[Tests] re-enable roks and vsi pattern tests in SLZ using Key Protect instead of HPCS

### DIFF
--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -123,15 +123,15 @@ func setupOptionsRoksPattern(t *testing.T, prefix string) *testhelper.TestOption
 }
 
 func TestRunRoksPatternWithHPCS(t *testing.T) {
-	// TODO: Re-enable HPCS tests once the auth policy issue is fixed. Issue: https://github.ibm.com/GoldenEye/issues/issues/5138
-	t.Skip("Skipping HPCS tests until the auth policy issue is resolved.")
-
 	t.Parallel()
 
 	options := setupOptionsRoksPattern(t, "lrkshp")
 
-	options.TerraformVars["hs_crypto_instance_name"] = permanentResources["hpcs_name_south"]
-	options.TerraformVars["hs_crypto_resource_group"] = permanentResources["hpcs_rg_south"]
+	// TODO: Use HPCS instead of Key Protect for tests once the auth policy issue is fixed. Issue: https://github.ibm.com/GoldenEye/issues/issues/5138
+
+	// Key Protect service will be used if `hs_crypto_instance_name` is null
+	// options.TerraformVars["hs_crypto_instance_name"] = permanentResources["hpcs_name_south"]
+	// options.TerraformVars["hs_crypto_resource_group"] = permanentResources["hpcs_rg_south"]
 
 	output, err := options.RunTestConsistency()
 	assert.Nil(t, err, "This should not have errored")
@@ -189,13 +189,13 @@ func TestRunUpgradeVsiPattern(t *testing.T) {
 }
 
 func TestRunVSIPatternWithHPCS(t *testing.T) {
-	// TODO: Re-enable HPCS tests once the auth policy issue is fixed. Issue: https://github.ibm.com/GoldenEye/issues/issues/5138
-	t.Skip("Skipping HPCS tests until the auth policy issue is resolved.")
-
 	options := setupOptionsVsiPattern(t, "lvsihp")
 
-	options.TerraformVars["hs_crypto_instance_name"] = permanentResources["hpcs_name_south"]
-	options.TerraformVars["hs_crypto_resource_group"] = permanentResources["hpcs_rg_south"]
+	// TODO: Use HPCS instead of Key Protect for tests once the auth policy issue is fixed. Issue: https://github.ibm.com/GoldenEye/issues/issues/5138
+
+	// Key Protect service will be used if `hs_crypto_instance_name` is null
+	// options.TerraformVars["hs_crypto_instance_name"] = permanentResources["hpcs_name_south"]
+	// options.TerraformVars["hs_crypto_resource_group"] = permanentResources["hpcs_rg_south"]
 
 	output, err := options.RunTestConsistency()
 	assert.Nil(t, err, "This should not have errored")


### PR DESCRIPTION

### Description
re-enabled roks and vsi pattern tests in SLZ using Key Protect instead of HPCS

### Types of changes in this PR

#### Changes that affect the core Terraform module or submodules
- [ ] Bug fix
- [ ] New feature
- [ ] Dependency update

#### Changes that don't affect the core Terraform module or submodules
- [x] Examples or tests (addition or updates of examples or tests)
- [ ] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other

#### Release required?
Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning).

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
