### PR TITLE
fix(deps) update DAs IBM provider version to 1.56.1

### DIFF
--- a/examples/one-vpc-one-vsi/version.tf
+++ b/examples/one-vpc-one-vsi/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.54.0"
+      version = "1.56.1"
     }
   }
 }

--- a/examples/override-example/version.tf
+++ b/examples/override-example/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.54.0"
+      version = "1.56.1"
     }
   }
 }

--- a/patterns/mixed/versions.tf
+++ b/patterns/mixed/versions.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.54.0"
+      version = "1.56.1"
     }
     external = {
       source  = "hashicorp/external"

--- a/patterns/roks/versions.tf
+++ b/patterns/roks/versions.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.54.0"
+      version = "1.56.1"
     }
     # tflint-ignore: terraform_unused_required_providers
     external = {

--- a/patterns/vpc/version.tf
+++ b/patterns/vpc/version.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.54.0"
+      version = "1.56.1"
     }
     # tflint-ignore: terraform_unused_required_providers
     external = {

--- a/patterns/vsi-quickstart/version.tf
+++ b/patterns/vsi-quickstart/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.54.0"
+      version = "1.56.1"
     }
   }
 }

--- a/patterns/vsi/versions.tf
+++ b/patterns/vsi/versions.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.54.0"
+      version = "1.56.1"
     }
     # tflint-ignore: terraform_unused_required_providers
     external = {


### PR DESCRIPTION
### Description

update DA IBM provider versions to 1.56.1 to pull in fix for https://github.com/IBM-Cloud/terraform-provider-ibm/pull/4755

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- When merging, use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
