### PR TITLE
fix: update the ssh key related variable descriptions for the OCP pattern

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -1003,6 +1003,10 @@
                             "key": "ssh_public_key"
                         },
                         {
+                            "hidden": true,
+                            "key": "existing_ssh_key_name"
+                        },
+                        {
                             "custom_config": {
                                 "config_constraints": {
                                     "generationType": "2"

--- a/patterns/roks/module/variables.tf
+++ b/patterns/roks/module/variables.tf
@@ -207,7 +207,7 @@ variable "vpn_firewall_type" {
 }
 
 variable "ssh_public_key" {
-  description = "Public SSH Key. Must be an RSA key with a key size of either 2048 bits or 4096 bits (recommended) - See https://cloud.ibm.com/docs/vpc?topic=vpc-ssh-keys. Must not already exists in the deployment region. Use only if provisioning F5 or Bastion Host."
+  description = "A public SSH key that does not exist in the deployment region. Used only if you provision F5 or Bastion Host. Must be an RSA key with a key size of either 2048 or 4096 bits (recommended). See https://cloud.ibm.com/docs/vpc?topic=vpc-ssh-keys. To use an existing key, specify a value in the `existing_ssh_key_name` variable instead."
   type        = string
   default     = null
   validation {
@@ -217,7 +217,7 @@ variable "ssh_public_key" {
 }
 
 variable "existing_ssh_key_name" {
-  description = "The name of the public ssh key which already exists."
+  description = "The name of a public SSH key that exists in the deployment region. Used only if you provision F5 or Bastion Host. To add a SSH key, use the `ssh_public_key` variable instead."
   type        = string
   default     = null
 }

--- a/patterns/roks/variables.tf
+++ b/patterns/roks/variables.tf
@@ -221,7 +221,7 @@ variable "vpn_firewall_type" {
 }
 
 variable "ssh_public_key" {
-  description = "A public SSH Key which does not already exist in the deployment region. Used only if provisioning F5 or Bastion Host. Must be an RSA key with a key size of either 2048 bits or 4096 bits (recommended) - See https://cloud.ibm.com/docs/vpc?topic=vpc-ssh-keys. To use an existing key, enter a value for the variable 'existing_ssh_key_name' instead."
+  description = "A public SSH key that does not exist in the deployment region. Used only if you provision F5 or Bastion Host. Must be an RSA key with a key size of either 2048 or 4096 bits (recommended). See https://cloud.ibm.com/docs/vpc?topic=vpc-ssh-keys. To use an existing key, specify a value in the `existing_ssh_key_name` variable instead."
   type        = string
   default     = null
   validation {
@@ -231,7 +231,7 @@ variable "ssh_public_key" {
 }
 
 variable "existing_ssh_key_name" {
-  description = "The name of a public SSH Key which already exists in the deployment region. Used only if provisioning F5 or Bastion Host. To add a new SSH key, use the variable 'ssh_public_key' instead."
+  description = "The name of a public SSH key that exists in the deployment region. Used only if you provision F5 or Bastion Host. To add a SSH key, use the `ssh_public_key` variable instead."
   type        = string
   default     = null
 }

--- a/patterns/roks/variables.tf
+++ b/patterns/roks/variables.tf
@@ -221,7 +221,7 @@ variable "vpn_firewall_type" {
 }
 
 variable "ssh_public_key" {
-  description = "Public SSH Key. Must be an RSA key with a key size of either 2048 bits or 4096 bits (recommended) - See https://cloud.ibm.com/docs/vpc?topic=vpc-ssh-keys. Must not already exists in the deployment region. Use only if provisioning F5 or Bastion Host."
+  description = "A public SSH Key which does not already exist in the deployment region. Used only if provisioning F5 or Bastion Host. Must be an RSA key with a key size of either 2048 bits or 4096 bits (recommended) - See https://cloud.ibm.com/docs/vpc?topic=vpc-ssh-keys. To use an existing key, enter a value for the variable 'existing_ssh_key_name' instead."
   type        = string
   default     = null
   validation {
@@ -231,7 +231,7 @@ variable "ssh_public_key" {
 }
 
 variable "existing_ssh_key_name" {
-  description = "The name of the public ssh key which already exists."
+  description = "The name of a public SSH Key which already exists in the deployment region. Used only if provisioning F5 or Bastion Host. To add a new SSH key, use the variable 'ssh_public_key' instead."
   type        = string
   default     = null
 }


### PR DESCRIPTION
### Description

- Update the ssh key related variable descriptions for the OCP pattern (DA)
- Hide the `existing_ssh_key_name` variable from catalog since all of the F5 and Bastion variables are hidden. (NOTE: `ssh_public_key` is already hidden but seems `existing_ssh_key_name` was missed).

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- When merging, use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
