### PR TITLE
test: do not use jp-osa region for HPCS tests

### DIFF
--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -18,7 +18,7 @@ func TestRunRoksPatternWithHPCS(t *testing.T) {
 	// If "jp-osa" was the best region selected, default to us-south instead.
 	// "jp-osa" is currently not allowing hs-crypto be used for encrypting buckets in that region.
 	currentRegion, ok := options.TerraformVars["region"]
-	if !ok || currentRegion == "jp-osa" {
+	if ok && currentRegion == "jp-osa" {
 		options.TerraformVars["region"] = "us-south"
 	}
 
@@ -38,7 +38,7 @@ func TestRunVSIPatternWithHPCS(t *testing.T) {
 	// If "jp-osa" was the best region selected, default to us-south instead.
 	// "jp-osa" is currently not allowing hs-crypto be used for encrypting buckets in that region.
 	currentRegion, ok := options.TerraformVars["region"]
-	if !ok || currentRegion == "jp-osa" {
+	if ok && currentRegion == "jp-osa" {
 		options.TerraformVars["region"] = "us-south"
 	}
 

--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -15,6 +15,12 @@ func TestRunRoksPatternWithHPCS(t *testing.T) {
 
 	options.TerraformVars["hs_crypto_instance_name"] = permanentResources["hpcs_name_south"]
 	options.TerraformVars["hs_crypto_resource_group"] = permanentResources["hpcs_rg_south"]
+	// If "jp-osa" was the best region selected, default to us-south instead.
+	// "jp-osa" is currently not allowing hs-crypto be used for encrypting buckets in that region.
+	currentRegion, ok := options.TerraformVars["region"]
+	if !ok || currentRegion == "jp-osa" {
+		options.TerraformVars["region"] = "us-south"
+	}
 
 	output, err := options.RunTestConsistency()
 	assert.Nil(t, err, "This should not have errored")
@@ -29,6 +35,12 @@ func TestRunVSIPatternWithHPCS(t *testing.T) {
 
 	options.TerraformVars["hs_crypto_instance_name"] = permanentResources["hpcs_name_south"]
 	options.TerraformVars["hs_crypto_resource_group"] = permanentResources["hpcs_rg_south"]
+	// If "jp-osa" was the best region selected, default to us-south instead.
+	// "jp-osa" is currently not allowing hs-crypto be used for encrypting buckets in that region.
+	currentRegion, ok := options.TerraformVars["region"]
+	if !ok || currentRegion == "jp-osa" {
+		options.TerraformVars["region"] = "us-south"
+	}
 
 	output, err := options.RunTestConsistency()
 	assert.Nil(t, err, "This should not have errored")


### PR DESCRIPTION
### Description

The region `jp-osa` is currently not allowing hs-crypto keys to be used for COS bucket encryption (server side). When that region is selected as the best region to run the HPCS unit tests, those tests will fail.

If `jp-osa` is chosen as the best region for HPCS tests, we will now default back to region `us-south` instead.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

The region `jp-osa` is currently not allowing hs-crypto keys to be used for COS bucket encryption (server side). Unit tests have been updated to make sure this region is not used for any HPCS tests.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
