### PR TITLE
fix(deps): bump ibm tf provider version to 1.59.0 for all SLZ DAs

### DIFF
--- a/examples/one-vpc-one-vsi/main.tf
+++ b/examples/one-vpc-one-vsi/main.tf
@@ -3,11 +3,10 @@
 ##############################################################################
 
 module "landing_zone" {
-  source           = "../../patterns/vsi"
-  prefix           = var.prefix
-  region           = var.region
-  ibmcloud_api_key = var.ibmcloud_api_key
-  ssh_public_key   = var.ssh_key
-  override         = true
-  tags             = var.resource_tags
+  source         = "../../patterns/vsi/module"
+  prefix         = var.prefix
+  region         = var.region
+  ssh_public_key = var.ssh_key
+  override       = true
+  tags           = var.resource_tags
 }

--- a/examples/one-vpc-one-vsi/version.tf
+++ b/examples/one-vpc-one-vsi/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.59.0"
+      version = ">= 1.59.0"
     }
   }
 }

--- a/examples/one-vpc-one-vsi/version.tf
+++ b/examples/one-vpc-one-vsi/version.tf
@@ -1,10 +1,9 @@
 terraform {
   required_version = ">= 1.3, < 1.6"
   required_providers {
-    # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.59.0"
+      version = "1.58.1"
     }
   }
 }

--- a/examples/one-vpc-one-vsi/version.tf
+++ b/examples/one-vpc-one-vsi/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.58.1"
+      version = "1.59.0"
     }
   }
 }

--- a/examples/one-vpc-one-vsi/version.tf
+++ b/examples/one-vpc-one-vsi/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.59.0"
+      version = "1.59.0"
     }
   }
 }

--- a/examples/one-vpc-one-vsi/version.tf
+++ b/examples/one-vpc-one-vsi/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.58.1"
+      version = "1.59.0"
     }
   }
 }

--- a/examples/override-example/main.tf
+++ b/examples/override-example/main.tf
@@ -3,11 +3,10 @@
 ##############################################################################
 
 module "landing_zone" {
-  source           = "../../patterns/vsi"
-  prefix           = var.prefix
-  region           = var.region
-  ibmcloud_api_key = var.ibmcloud_api_key
-  ssh_public_key   = var.ssh_key
-  override         = true
-  tags             = var.resource_tags
+  source         = "../../patterns/vsi/module"
+  prefix         = var.prefix
+  region         = var.region
+  ssh_public_key = var.ssh_key
+  override       = true
+  tags           = var.resource_tags
 }

--- a/examples/override-example/version.tf
+++ b/examples/override-example/version.tf
@@ -1,10 +1,9 @@
 terraform {
   required_version = ">= 1.3, < 1.6"
   required_providers {
-    # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.58.1"
+      version = "1.59.0"
     }
   }
 }

--- a/examples/override-example/version.tf
+++ b/examples/override-example/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.59.0"
+      version = ">= 1.59.0"
     }
   }
 }

--- a/examples/override-example/version.tf
+++ b/examples/override-example/version.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.59.0"
+      version = "1.59.0"
     }
   }
 }

--- a/patterns/mixed/versions.tf
+++ b/patterns/mixed/versions.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.58.1"
+      version = "1.59.0"
     }
     external = {
       source  = "hashicorp/external"

--- a/patterns/roks/versions.tf
+++ b/patterns/roks/versions.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.58.1"
+      version = "1.59.0"
     }
     # tflint-ignore: terraform_unused_required_providers
     external = {

--- a/patterns/vpc/version.tf
+++ b/patterns/vpc/version.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.58.1"
+      version = "1.59.0"
     }
     # tflint-ignore: terraform_unused_required_providers
     external = {

--- a/patterns/vsi-extension/version.tf
+++ b/patterns/vsi-extension/version.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.56.1"
+      version = "1.59.0"
     }
     # tflint-ignore: terraform_unused_required_providers
     external = {

--- a/patterns/vsi-quickstart/version.tf
+++ b/patterns/vsi-quickstart/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.58.1"
+      version = "1.59.0"
     }
   }
 }

--- a/patterns/vsi/versions.tf
+++ b/patterns/vsi/versions.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.58.1"
+      version = "1.59.0"
     }
     # tflint-ignore: terraform_unused_required_providers
     external = {


### PR DESCRIPTION
### Description

bump ibm tf provider version to 1.59.0 for all SLZ DAs to pick up fixes around private OCP cluster certs

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
