### PR TITLE
test: ignore resource group destroy

### DIFF
--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testschematic"
 )
 
 // NOTE: The HPCS tests may fail if our account already has an existing hpcs auth policy - hence only running once a week so PR pipeline is not impacted
@@ -47,4 +48,76 @@ func TestRunVSIPatternWithHPCS(t *testing.T) {
 	output, err := options.RunTestConsistency()
 	assert.Nil(t, err, "This should not have errored")
 	assert.NotNil(t, output, "Expected some output")
+}
+
+func TestRunVSIQuickStartPatternSchematics(t *testing.T) {
+	t.Parallel()
+
+	options := setupOptionsSchematics(t, "qs-sc", quickStartPatternTerraformDir)
+
+	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
+		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
+		{Name: "region", Value: options.Region, DataType: "string"},
+		{Name: "prefix", Value: options.Prefix, DataType: "string"},
+		{Name: "ssh_key", Value: sshPublicKey(t), DataType: "string"},
+		{Name: "service_endpoints", Value: "private", DataType: "string"},
+	}
+
+	err := options.RunSchematicTest()
+	assert.NoError(t, err, "Schematic Test had unexpected error")
+}
+
+func TestRunVSIPatternSchematics(t *testing.T) {
+	t.Parallel()
+
+	options := setupOptionsSchematics(t, "vsi-sc", vsiPatternTerraformDir)
+
+	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
+		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
+		{Name: "region", Value: options.Region, DataType: "string"},
+		{Name: "prefix", Value: options.Prefix, DataType: "string"},
+		{Name: "ssh_public_key", Value: sshPublicKey(t), DataType: "string"},
+		{Name: "add_atracker_route", Value: add_atracker_route, DataType: "bool"},
+		{Name: "service_endpoints", Value: "private", DataType: "string"},
+	}
+
+	err := options.RunSchematicTest()
+	assert.NoError(t, err, "Schematic Test had unexpected error")
+}
+
+func TestRunRoksPatternSchematics(t *testing.T) {
+	t.Parallel()
+
+	options := setupOptionsSchematics(t, "ocp-sc", roksPatternTerraformDir)
+
+	options.WaitJobCompleteMinutes = 120
+
+	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
+		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
+		{Name: "region", Value: options.Region, DataType: "string"},
+		{Name: "prefix", Value: options.Prefix, DataType: "string"},
+		{Name: "tags", Value: options.Tags, DataType: "list(string)"},
+		{Name: "service_endpoints", Value: "private", DataType: "string"},
+	}
+
+	err := options.RunSchematicTest()
+	assert.NoError(t, err, "Schematic Test had unexpected error")
+}
+
+func TestRunVPCPatternSchematics(t *testing.T) {
+	t.Parallel()
+
+	options := setupOptionsSchematics(t, "vpc-sc", vpcPatternTerraformDir)
+
+	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
+		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
+		{Name: "region", Value: options.Region, DataType: "string"},
+		{Name: "prefix", Value: options.Prefix, DataType: "string"},
+		{Name: "tags", Value: options.Tags, DataType: "list(string)"},
+		{Name: "add_atracker_route", Value: add_atracker_route, DataType: "bool"},
+		{Name: "service_endpoints", Value: "private", DataType: "string"},
+	}
+
+	err := options.RunSchematicTest()
+	assert.NoError(t, err, "Schematic Test had unexpected error")
 }

--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testschematic"
 )
 
 // NOTE: The HPCS tests may fail if our account already has an existing hpcs auth policy - hence only running once a week so PR pipeline is not impacted
@@ -48,76 +47,4 @@ func TestRunVSIPatternWithHPCS(t *testing.T) {
 	output, err := options.RunTestConsistency()
 	assert.Nil(t, err, "This should not have errored")
 	assert.NotNil(t, output, "Expected some output")
-}
-
-func TestRunVSIQuickStartPatternSchematics(t *testing.T) {
-	t.Parallel()
-
-	options := setupOptionsSchematics(t, "qs-sc", quickStartPatternTerraformDir)
-
-	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
-		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
-		{Name: "region", Value: options.Region, DataType: "string"},
-		{Name: "prefix", Value: options.Prefix, DataType: "string"},
-		{Name: "ssh_key", Value: sshPublicKey(t), DataType: "string"},
-		{Name: "service_endpoints", Value: "private", DataType: "string"},
-	}
-
-	err := options.RunSchematicTest()
-	assert.NoError(t, err, "Schematic Test had unexpected error")
-}
-
-func TestRunVSIPatternSchematics(t *testing.T) {
-	t.Parallel()
-
-	options := setupOptionsSchematics(t, "vsi-sc", vsiPatternTerraformDir)
-
-	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
-		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
-		{Name: "region", Value: options.Region, DataType: "string"},
-		{Name: "prefix", Value: options.Prefix, DataType: "string"},
-		{Name: "ssh_public_key", Value: sshPublicKey(t), DataType: "string"},
-		{Name: "add_atracker_route", Value: add_atracker_route, DataType: "bool"},
-		{Name: "service_endpoints", Value: "private", DataType: "string"},
-	}
-
-	err := options.RunSchematicTest()
-	assert.NoError(t, err, "Schematic Test had unexpected error")
-}
-
-func TestRunRoksPatternSchematics(t *testing.T) {
-	t.Parallel()
-
-	options := setupOptionsSchematics(t, "ocp-sc", roksPatternTerraformDir)
-
-	options.WaitJobCompleteMinutes = 120
-
-	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
-		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
-		{Name: "region", Value: options.Region, DataType: "string"},
-		{Name: "prefix", Value: options.Prefix, DataType: "string"},
-		{Name: "tags", Value: options.Tags, DataType: "list(string)"},
-		{Name: "service_endpoints", Value: "private", DataType: "string"},
-	}
-
-	err := options.RunSchematicTest()
-	assert.NoError(t, err, "Schematic Test had unexpected error")
-}
-
-func TestRunVPCPatternSchematics(t *testing.T) {
-	t.Parallel()
-
-	options := setupOptionsSchematics(t, "vpc-sc", vpcPatternTerraformDir)
-
-	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
-		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
-		{Name: "region", Value: options.Region, DataType: "string"},
-		{Name: "prefix", Value: options.Prefix, DataType: "string"},
-		{Name: "tags", Value: options.Tags, DataType: "list(string)"},
-		{Name: "add_atracker_route", Value: add_atracker_route, DataType: "bool"},
-		{Name: "service_endpoints", Value: "private", DataType: "string"},
-	}
-
-	err := options.RunSchematicTest()
-	assert.NoError(t, err, "Schematic Test had unexpected error")
 }

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -40,7 +40,6 @@ var sharedInfoSvc *cloudinfo.CloudInfoService
 var permanentResources map[string]interface{}
 
 // Turn on Schematics tests, which can also skip the normal tests for same pattern
-// Values to enable: TRUE or YES
 var enableSchematicsTests bool
 
 // TestMain will be run before any parallel tests, used to set up a shared InfoService object to track region usage
@@ -54,13 +53,9 @@ func TestMain(m *testing.M) {
 		log.Fatal(err)
 	}
 
-	// Determine enable of Schematics tests via env (if unset value will be empty)
-	schematicsEnv := os.Getenv("RUN_SCHEMATICS_TESTS")
-	if strings.ToLower(schematicsEnv) == "true" || strings.ToLower(schematicsEnv) == "yes" {
-		enableSchematicsTests = true
-	} else {
-		enableSchematicsTests = false
-	}
+	// ENABLE SCHEMATICS TESTS
+	// To enable Schematics tests, and skip terratest for patterns, set boolean to true
+	enableSchematicsTests = false
 
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
### Description

Due to issues with resource group deletion (reclamation issues), this change will cause all unit tests to ignore `destroy` of resource groups created by using the `ImplicitDestroy` feature of `ibmcloud-terratest-wrapper`, which will remove the resource groups from terraform state before `destroy`.

Because there is no `ImplicitDestroy` feature for Schematics tests, those unit tests have been moved from PR tests into the "Other" tests so that this resource group delete issue does not block pull requests.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content


### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
