### PR TITLE
fix: fix the way service endpoint type is passed to Key Protect

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-12-12T18:26:42Z",
+  "generated_at": "2023-12-13T18:26:42Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/kms/main.tf
+++ b/kms/main.tf
@@ -25,7 +25,9 @@ resource "ibm_resource_instance" "kms" {
   location          = var.region
   resource_group_id = var.key_management.resource_group_id
   tags              = var.key_management.tags
-  service_endpoints = var.service_endpoints
+  parameters = {
+    allowed_network : var.service_endpoints
+  }
 }
 
 resource "ibm_resource_tag" "tag" {


### PR DESCRIPTION
### Description

In order to set endpoint type for Key Protect, you have to pass it as a parameter like this:
```
parameters = {
   allowed_network: "public-and-private",
 }
```

It should not be passed directly into `ibm_resource_instance` like we are doing now, as it is a special case.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
