### PR TITLE
refactor: added depends_on on cluster for s2s auth policy

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -36,6 +36,7 @@ locals {
 ##############################################################################
 
 resource "ibm_container_vpc_cluster" "cluster" {
+  depends_on        = [ibm_iam_authorization_policy.policy]
   for_each          = local.clusters_map
   name              = "${var.prefix}-${each.value.name}"
   vpc_id            = each.value.vpc_id


### PR DESCRIPTION
### Description

The kms s2s policy must exist during cluster deletion hence added depends on to prevent deletion of auth policy.

Git issue: https://github.com/terraform-ibm-modules/terraform-ibm-landing-zone/issues/738

### Release required?

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
