### PR TITLE
fix: expose cluster entitlement variable for OCP quickstart

### DIFF
--- a/patterns/roks-quickstart/main.tf
+++ b/patterns/roks-quickstart/main.tf
@@ -5,6 +5,7 @@
 locals {
   default_ocp_version = "${data.ibm_container_cluster_versions.cluster_versions.default_openshift_version}_openshift"
   ocp_version         = var.kube_version == null || var.kube_version == "default" ? local.default_ocp_version : "${var.kube_version}_openshift"
+  entitlement_val     = var.entitlement == null ? "null" : "\"${var.entitlement}\""
 }
 
 data "ibm_container_cluster_versions" "cluster_versions" {
@@ -48,7 +49,7 @@ locals {
          "vpc_name": "workload",
          "worker_pools": [],
          "workers_per_subnet": 1,
-         "entitlement": "${var.entitlement}",
+         "entitlement": ${local.entitlement_val},
          "disable_public_endpoint": false
       }
    ],

--- a/patterns/roks-quickstart/main.tf
+++ b/patterns/roks-quickstart/main.tf
@@ -48,7 +48,7 @@ locals {
          "vpc_name": "workload",
          "worker_pools": [],
          "workers_per_subnet": 1,
-         "entitlement": "cloud_pak",
+         "entitlement": "${var.entitlement}",
          "disable_public_endpoint": false
       }
    ],

--- a/patterns/roks-quickstart/variables.tf
+++ b/patterns/roks-quickstart/variables.tf
@@ -42,3 +42,9 @@ variable "flavor" {
   type        = string
   default     = "bx2.4x16"
 }
+
+variable "entitlement" {
+  description = "If you do not have an entitlement, leave as null. Entitlement reduces additional OCP Licence cost in OpenShift clusters. Use Cloud Pak with OCP Licence entitlement to create the OpenShift cluster. Note It is set only when the first time creation of the cluster, further modifications are not impacted Set this argument to cloud_pak only if you use the cluster with a Cloud Pak that has an OpenShift entitlement."
+  type        = string
+  default     = null
+}

--- a/patterns/roks-quickstart/variables.tf
+++ b/patterns/roks-quickstart/variables.tf
@@ -11,7 +11,7 @@ variable "ibmcloud_api_key" {
 variable "prefix" {
   description = "A unique identifier for resources. Must begin with a lowercase letter and end with a lowercase letter or number. This prefix will be prepended to any resources provisioned by this template. Prefixes must be 13 or fewer characters."
   type        = string
-  default     = "land-zone-roks-qs"
+  default     = "lz-roks-qs"
 
   validation {
     error_message = "Prefix must begin with a letter and contain only lowercase letters, numbers, and - characters. Prefixes must end with a lowercase letter or number and be 13 or fewer characters."

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -157,6 +157,9 @@ func setupOptionsROKSQuickStartPattern(t *testing.T, prefix string, dir string) 
 		TerraformDir:     dir,
 		Prefix:           prefix,
 		CloudInfoService: sharedInfoSvc,
+		TerraformVars: map[string]interface{}{
+			"entitlement": "cloud_pak",
+		},
 	})
 
 	return options
@@ -201,9 +204,11 @@ func setupOptionsRoksPattern(t *testing.T, prefix string) *testhelper.TestOption
 	})
 
 	options.TerraformVars = map[string]interface{}{
-		"prefix": options.Prefix,
-		"tags":   options.Tags,
-		"region": options.Region,
+		"prefix":      options.Prefix,
+		"tags":        options.Tags,
+		"region":      options.Region,
+		"entitlement": "cloud_pak",
+		"flavor":      "bx2.4x16",
 	}
 
 	return options
@@ -544,6 +549,7 @@ func TestRunROKSQuickStartPatternSchematics(t *testing.T) {
 		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
 		{Name: "region", Value: options.Region, DataType: "string"},
 		{Name: "prefix", Value: options.Prefix, DataType: "string"},
+		{Name: "entitlement", Value: "cloud_pak", DataType: "string"},
 	}
 
 	err := options.RunSchematicTest()
@@ -585,6 +591,8 @@ func TestRunRoksPatternSchematics(t *testing.T) {
 		{Name: "region", Value: options.Region, DataType: "string"},
 		{Name: "prefix", Value: options.Prefix, DataType: "string"},
 		{Name: "tags", Value: options.Tags, DataType: "list(string)"},
+		{Name: "entitlement", Value: "cloud_pak", DataType: "string"},
+		{Name: "flavor", Value: "bx2.4x16", DataType: "string"},
 	}
 
 	err := options.RunSchematicTest()


### PR DESCRIPTION
### Description

This change will add a new input variable to `patterns/roks-quickstart` for the field "cluster entitlement" which will allow consumers to specify a specific entitlement or leave null if their account does not have any entitlements (was previously set to "cloud_pak").

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
