### PR TITLE
feat: added eu-fr2 support in atracker and cos

### DIFF
--- a/atracker.tf
+++ b/atracker.tf
@@ -6,7 +6,7 @@
 
 locals {
   valid_atracker_region = contains(
-    ["us-south", "us-east", "eu-de", "eu-es", "eu-gb", "au-syd"],
+    ["us-south", "us-east", "eu-de", "eu-es", "eu-gb", "eu-fr2", "au-syd"],
     var.region
   )
 }

--- a/variables.tf
+++ b/variables.tf
@@ -642,7 +642,7 @@ variable "cos" {
 
   # https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/resources/cos_bucket#region_location
   validation {
-    error_message = "All regional buckets must specify `au-syd`, `eu-de`, `eu-es`, `eu-gb`, `jp-tok`, `us-east`, `us-south`, `ca-tor`, `jp-osa`, `br-sao`."
+    error_message = "All regional buckets must specify `au-syd`, `eu-de`, `eu-es`, `eu-gb`, `eu-fr2`, `jp-tok`, `us-east`, `us-south`, `ca-tor`, `jp-osa`, `br-sao`."
     condition = length(
       [
         for site_bucket in flatten(
@@ -653,7 +653,7 @@ variable "cos" {
               bucket if lookup(bucket, "region_location", null) != null
             ]
           ]
-        ) : site_bucket if !contains(["au-syd", "eu-de", "eu-es", "eu-gb", "jp-tok", "us-east", "us-south", "ca-tor", "jp-osa", "br-sao"], site_bucket.region_location)
+        ) : site_bucket if !contains(["au-syd", "eu-de", "eu-es", "eu-gb", "eu-fr2", "jp-tok", "us-east", "us-south", "ca-tor", "jp-osa", "br-sao"], site_bucket.region_location)
       ]
     ) == 0
   }


### PR DESCRIPTION
### Description
Added eu-fr2 in the supported regions for Atracker route creation and regional COS
https://github.com/terraform-ibm-modules/terraform-ibm-landing-zone/issues/773

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Added eu-fr2 in the supported regions for Atracker route creation and regional COS

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
