### PR TITLE
Update .catalog-onboard-pipeline.yaml to use projects again for validation

### DIFF
--- a/.catalog-onboard-pipeline.yaml
+++ b/.catalog-onboard-pipeline.yaml
@@ -10,18 +10,18 @@ offerings:
       - name: quickstart
         mark_ready: false
         install_type: fullstack
-        validation_type: schematics
+        validation_type: projects
       - name: standard
         mark_ready: false
         install_type: fullstack
-        validation_type: schematics
+        validation_type: projects
         scc:
           instance_id: 1c7d5f78-9262-44c3-b779-b28fe4d88c37
           region: us-south
       - name: existing-vpc
         mark_ready: false
         install_type: extension
-        validation_type: schematics
+        validation_type: projects
         pre_validation: "tests/scripts/pre-validation-deploy-slz-vpc.sh"
         post_validation: "tests/scripts/post-validation-destroy-slz-vpc.sh"
         scc:
@@ -36,7 +36,7 @@ offerings:
       - name: standard
         mark_ready: false
         install_type: fullstack
-        validation_type: schematics
+        validation_type: projects
         scc:
           instance_id: 1c7d5f78-9262-44c3-b779-b28fe4d88c37
           region: us-south
@@ -49,11 +49,11 @@ offerings:
       - name: standard
         mark_ready: false
         install_type: fullstack
-        validation_type: schematics
+        validation_type: projects
         scc:
           instance_id: 1c7d5f78-9262-44c3-b779-b28fe4d88c37
           region: us-south
       - name: quickstart
         mark_ready: false
         install_type: fullstack
-        validation_type: schematics
+        validation_type: projects


### PR DESCRIPTION
### Description

Update .catalog-onboard-pipeline.yaml to use projects again for validation since the timeout issue we had been seen has been fixed in prod

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
