### PR TITLE
fix: resource group names

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -271,12 +271,12 @@ output "placement_groups" {
 
 output "resource_group_names" {
   description = "List of resource groups names used within landing zone."
-  value       = keys(local.resource_groups)
+  value       = keys(local.resource_groups_info)
 }
 
 output "resource_group_data" {
   description = "List of resource groups data used within landing zone."
-  value       = local.resource_groups
+  value       = local.resource_groups_info
 }
 
 


### PR DESCRIPTION
### Description

https://github.com/terraform-ibm-modules/terraform-ibm-landing-zone/issues/851

landing-zone output `resource_group_names` does not contain proper values

https://github.com/terraform-ibm-modules/terraform-ibm-landing-zone/blob/14b3656b0787f7da81163a98726b739a90b20ca1/resource_groups.tf#L42

https://github.com/terraform-ibm-modules/terraform-ibm-landing-zone/blob/14b3656b0787f7da81163a98726b739a90b20ca1/outputs.tf#L274

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

fix for landing-zone output `resource_group_names` does not containing proper values

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
