### PR TITLE
fix: added outputs for cluster names

### DIFF
--- a/README.md
+++ b/README.md
@@ -962,6 +962,7 @@ module "cluster_pattern" {
 | <a name="output_key_map"></a> [key\_map](#output\_key\_map) | Map of ids and keys for keys created |
 | <a name="output_key_rings"></a> [key\_rings](#output\_key\_rings) | Key rings created by module |
 | <a name="output_management_cluster_id"></a> [management\_cluster\_id](#output\_management\_cluster\_id) | The id of the management cluster. If the cluster name does not exactly match the prefix-management-cluster pattern it will be null. |
+| <a name="output_management_cluster_name"></a> [management\_cluster\_name](#output\_management\_cluster\_name) | The name of the management cluster. If the cluster name does not exactly match the prefix-management-cluster pattern it will be null. |
 | <a name="output_placement_groups"></a> [placement\_groups](#output\_placement\_groups) | List of placement groups. |
 | <a name="output_resource_group_data"></a> [resource\_group\_data](#output\_resource\_group\_data) | List of resource groups data used within landing zone. |
 | <a name="output_resource_group_names"></a> [resource\_group\_names](#output\_resource\_group\_names) | List of resource groups names used within landing zone. |
@@ -986,6 +987,7 @@ module "cluster_pattern" {
 | <a name="output_vsi_data"></a> [vsi\_data](#output\_vsi\_data) | A list of VSI with name, id, zone, and primary ipv4 address, VPC Name, and floating IP. |
 | <a name="output_vsi_names"></a> [vsi\_names](#output\_vsi\_names) | List of VSI names |
 | <a name="output_workload_cluster_id"></a> [workload\_cluster\_id](#output\_workload\_cluster\_id) | The id of the workload cluster. If the cluster name does not exactly match the prefix-workload-cluster pattern it will be null. |
+| <a name="output_workload_cluster_name"></a> [workload\_cluster\_name](#output\_workload\_cluster\_name) | The name of the workload cluster. If the cluster name does not exactly match the prefix-workload-cluster pattern it will be null. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 <!-- Leave this section as is so that your module has a link to local development environment set up steps for contributors to follow -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -79,9 +79,19 @@ output "workload_cluster_id" {
   value       = lookup(ibm_container_vpc_cluster.cluster, "${var.prefix}-workload-cluster", null) != null ? ibm_container_vpc_cluster.cluster["${var.prefix}-workload-cluster"].id : null
 }
 
+output "workload_cluster_name" {
+  description = "The name of the workload cluster. If the cluster name does not exactly match the prefix-workload-cluster pattern it will be null."
+  value       = lookup(ibm_container_vpc_cluster.cluster, "${var.prefix}-workload-cluster", null) != null ? ibm_container_vpc_cluster.cluster["${var.prefix}-workload-cluster"].name : null
+}
+
 output "management_cluster_id" {
   description = "The id of the management cluster. If the cluster name does not exactly match the prefix-management-cluster pattern it will be null."
   value       = lookup(ibm_container_vpc_cluster.cluster, "${var.prefix}-management-cluster", null) != null ? ibm_container_vpc_cluster.cluster["${var.prefix}-management-cluster"].id : null
+}
+
+output "management_cluster_name" {
+  description = "The name of the management cluster. If the cluster name does not exactly match the prefix-management-cluster pattern it will be null."
+  value       = lookup(ibm_container_vpc_cluster.cluster, "${var.prefix}-management-cluster", null) != null ? ibm_container_vpc_cluster.cluster["${var.prefix}-management-cluster"].name : null
 }
 
 output "cluster_data" {

--- a/patterns/roks/module/outputs.tf
+++ b/patterns/roks/module/outputs.tf
@@ -87,9 +87,19 @@ output "workload_cluster_id" {
   value       = module.landing_zone.workload_cluster_id
 }
 
+output "workload_cluster_name" {
+  description = "The name of the worload cluster. If the cluster name does not exactly match the prefix-workload-cluster pattern it will be null."
+  value       = module.landing_zone.workload_cluster_name
+}
+
 output "management_cluster_id" {
   description = "The id of the management cluster. If the cluster name does not exactly match the prefix-management-cluster pattern it will be null."
   value       = module.landing_zone.management_cluster_id
+}
+
+output "management_cluster_name" {
+  description = "The name of the management cluster. If the cluster name does not exactly match the prefix-management-cluster pattern it will be null."
+  value       = module.landing_zone.management_cluster_name
 }
 
 output "workload_cluster_ingress_hostname" {

--- a/patterns/roks/outputs.tf
+++ b/patterns/roks/outputs.tf
@@ -87,9 +87,19 @@ output "workload_cluster_id" {
   value       = module.roks_landing_zone.workload_cluster_id
 }
 
+output "workload_cluster_name" {
+  description = "The name of the workload cluster. If the cluster name does not exactly match the prefix-workload-cluster pattern it will be null."
+  value       = module.roks_landing_zone.workload_cluster_name
+}
+
 output "management_cluster_id" {
   description = "The id of the management cluster. If the cluster name does not exactly match the prefix-management-cluster pattern it will be null."
   value       = module.roks_landing_zone.management_cluster_id
+}
+
+output "management_cluster_name" {
+  description = "The name of the management cluster. If the cluster name does not exactly match the prefix-management-cluster pattern it will be null."
+  value       = module.roks_landing_zone.management_cluster_name
 }
 
 output "workload_cluster_ingress_hostname" {


### PR DESCRIPTION
### Description

Added new outputs for OCP cluster names (workload and management) to support new Projects stacks.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
