### PR TITLE
feat: roks pattern - add option to ignore vpcs for clusters

### DIFF
--- a/patterns/roks/main.tf
+++ b/patterns/roks/main.tf
@@ -27,6 +27,7 @@ module "roks_landing_zone" {
   wait_till                              = var.wait_till
   network_cidr                           = var.network_cidr
   vpcs                                   = var.vpcs
+  ignore_vpcs_for_cluster_deployment     = var.ignore_vpcs_for_cluster_deployment
   enable_transit_gateway                 = var.enable_transit_gateway
   transit_gateway_global                 = var.transit_gateway_global
   ssh_public_key                         = var.ssh_public_key

--- a/patterns/roks/module/config.tf
+++ b/patterns/roks/module/config.tf
@@ -68,6 +68,9 @@ locals {
   # Dynamic configuration for landing zone environment
   ##############################################################################
 
+  # create cluster vpc list by subtracting names from supplied ignore list
+  cluster_vpcs = setsubtract(var.vpcs, var.ignore_vpcs_for_cluster_deployment)
+
   config = {
 
     ##############################################################################
@@ -75,7 +78,7 @@ locals {
     ##############################################################################
     clusters = [
       # Dynamically create identical cluster in each VPC
-      for network in var.vpcs :
+      for network in local.cluster_vpcs :
       {
         name     = "${network}-cluster"
         vpc_name = network

--- a/patterns/roks/module/variables.tf
+++ b/patterns/roks/module/variables.tf
@@ -50,6 +50,13 @@ variable "vpcs" {
   }
 }
 
+variable "ignore_vpcs_for_cluster_deployment" {
+  description = "List of VPCs from input `vpcs` that should be ignored when deploying OpenShift clusters. If empty then a cluster will be deployed in all VPCs specified in input `vpcs`."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
 variable "enable_transit_gateway" {
   description = "Create transit gateway"
   type        = bool

--- a/patterns/roks/variables.tf
+++ b/patterns/roks/variables.tf
@@ -56,6 +56,13 @@ variable "vpcs" {
   }
 }
 
+variable "ignore_vpcs_for_cluster_deployment" {
+  description = "List of VPCs from input `vpcs` that should be ignored when deploying OpenShift clusters. If empty then a cluster will be deployed in all VPCs specified in input `vpcs`."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
 variable "enable_transit_gateway" {
   description = "Create transit gateway"
   type        = bool


### PR DESCRIPTION
### Description

Added a new input parameter `ignore_vpcs_for_cluster_deployment` (list of strings) that can be supplied in the ROKS pattern by a consumer that will configure landing zone to ignore certain VPCs for deploying clusters.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Added a new input parameter `ignore_vpcs_for_cluster_deployment` to the roks pattern to allow consumer to ignore specific VPCs for deploying clusters.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
