### PR TITLE
docs: add api key creator to catalog roks permissions

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -55,9 +55,7 @@
           "name": "quickstart",
           "install_type": "fullstack",
           "working_directory": "patterns/vsi-quickstart",
-          "compliance": {
-
-          },
+          "compliance": {},
           "release_notes_url": "https://cloud.ibm.com/docs/secure-infrastructure-vpc?topic=secure-infrastructure-vpc-secure-infrastructure-vpc-relnotes",
           "configuration": [
             {
@@ -1010,9 +1008,7 @@
           "name": "quickstart",
           "install_type": "fullstack",
           "working_directory": "patterns/roks-quickstart",
-          "compliance": {
-
-          },
+          "compliance": {},
           "release_notes_url": "https://cloud.ibm.com/docs/secure-infrastructure-vpc?topic=secure-infrastructure-vpc-secure-infrastructure-vpc-relnotes",
           "configuration": [
             {
@@ -1039,6 +1035,12 @@
             {
               "role_crns": [
                 "crn:v1:bluemix:public:iam::::role:Administrator"
+              ],
+              "service_name": "iam-identity"
+            },
+            {
+              "role_crns": [
+                "crn:v1:bluemix:public:iam-identity::::serviceRole:UserApiKeyCreator"
               ],
               "service_name": "iam-identity"
             },
@@ -1140,9 +1142,7 @@
                   "value": "4.15_openshift"
                 }
               ],
-              "custom_config": {
-
-              }
+              "custom_config": {}
             },
             {
               "hidden": true,
@@ -1317,7 +1317,6 @@
               "hidden": true,
               "key": "use_existing_appid"
             },
-
             {
               "hidden": true,
               "key": "teleport_version"
@@ -1383,6 +1382,12 @@
             {
               "role_crns": [
                 "crn:v1:bluemix:public:iam::::role:Administrator"
+              ],
+              "service_name": "iam-identity"
+            },
+            {
+              "role_crns": [
+                "crn:v1:bluemix:public:iam-identity::::serviceRole:UserApiKeyCreator"
               ],
               "service_name": "iam-identity"
             },

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -1034,12 +1034,7 @@
             },
             {
               "role_crns": [
-                "crn:v1:bluemix:public:iam::::role:Administrator"
-              ],
-              "service_name": "iam-identity"
-            },
-            {
-              "role_crns": [
+                "crn:v1:bluemix:public:iam::::role:Administrator",
                 "crn:v1:bluemix:public:iam-identity::::serviceRole:UserApiKeyCreator"
               ],
               "service_name": "iam-identity"
@@ -1381,12 +1376,7 @@
             },
             {
               "role_crns": [
-                "crn:v1:bluemix:public:iam::::role:Administrator"
-              ],
-              "service_name": "iam-identity"
-            },
-            {
-              "role_crns": [
+                "crn:v1:bluemix:public:iam::::role:Administrator",
                 "crn:v1:bluemix:public:iam-identity::::serviceRole:UserApiKeyCreator"
               ],
               "service_name": "iam-identity"


### PR DESCRIPTION
### Description

Added the IAM API Key Creator role to the needed permissions for ROKS patterns in the ibm_catalog.json configuration.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
