### PR TITLE
Update OCP default to 4.16

### DIFF
--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -1118,7 +1118,6 @@
               "key": "kube_version",
               "type": "string",
               "required": true,
-              "default_value": "4.16_openshift",
               "options": [
                 {
                   "displayname": "4.12_openshift",

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -1118,7 +1118,7 @@
               "key": "kube_version",
               "type": "string",
               "required": true,
-              "default_value": "4.15_openshift",
+              "default_value": "4.16_openshift",
               "options": [
                 {
                   "displayname": "4.12_openshift",


### PR DESCRIPTION
### Description

Even though the default was set to 4.16 in variables.tf - it was not updated in ibm_catalog.json meaning the tile was never updated. I am removing the default value from the catalog manifest to prevent this from happening again, which means it will always use the default value in the terraform code.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
