### PR TITLE
Revert "feat: exposed the ability to set the `provider_visibility` in DA" and plugged test gaps

### DIFF
--- a/cra-config.yaml
+++ b/cra-config.yaml
@@ -7,7 +7,6 @@ CRA_TARGETS:
     CRA_ENVIRONMENT_VARIABLES:
       TF_VAR_prefix: "slz-vpc"
       TF_VAR_region: "us-south"
-      TF_VAR_provider_visibility: "public"
   - CRA_TARGET: "patterns/vsi"
     CRA_IGNORE_RULES_FILE: "cra-tf-validate-ignore-rules.json"
     PROFILE_ID: "fe96bd4d-9b37-40f2-b39f-a62760e326a3"  # SCC profile ID (currently set to 'IBM Cloud Framework for Financial Services' '1.7.0' profile).
@@ -15,11 +14,9 @@ CRA_TARGETS:
       TF_VAR_prefix: "slz-vsi"
       TF_VAR_region: "us-south"
       TF_VAR_ssh_public_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC/hfNI5cNjimtcVgNA1acGmi1iv7PTjKcF8D+8DqffkGMsY6vU7KtB1mASwVU8GMGLzU2qvGmXwHSANYqPOraEitgI06zhq5VXVvtjOR41IJjP+ssjHIbql+EDzls2yJuZd2g4Wmk5NKTzJFNYsvIaCGUYCSMUPT9bepUqIOyjsrCEiHGLaphF5W2V/hj1+1NEZqV3ozhmHmtff2tIb6+VQpd/dl61RKuF74rywd1krmBOe4kbPzfYRqiRKV0rl0bPuyL+FV3Zv5gdzRRLNQiOxapv9uSkCal3W0umpSQyBYtj6BhGxeKrBKVgXgdq7byStRFSlREaKIg+tkekieqNZbBArgSYoNACZilxrzzC6u0KuWtllldy1CwCtFEdBlSPnHwnD/XhAs6FVuoh5tmw+FLtVyg8UyMgSvVr1Vcya9uAOCLLiihsgAB5xqqcJaXcfk+zkWn7rUJ9F+R3CZs9rgEvBbHpFAKJqcMsInZ+G0Jt0s6kIpAPr/plcfrK2bcwG/L9Kbuedf31dmHAylKqfMpdqm2YoSXOs5Y7Wh6KV/1VhL/u0++hxGt6APjvpY0BTlvsw7fmBSPniHkC8fF6bEzP0blCRcI3SB7P/glrZqM5UptBoEI5a8LBv5G4YsVolRepj6FjwlPvfgBbLF5AXxFtZTk07UW7CRauO5xbJw=="
-      TF_VAR_provider_visibility: "public"
   - CRA_TARGET: "patterns/roks"
     CRA_IGNORE_RULES_FILE: "cra-tf-validate-ignore-rules.json"
     PROFILE_ID: "fe96bd4d-9b37-40f2-b39f-a62760e326a3"  # SCC profile ID (currently set to 'IBM Cloud Framework for Financial Services' '1.7.0' profile).
     CRA_ENVIRONMENT_VARIABLES:
       TF_VAR_prefix: "slz-roks"
       TF_VAR_region: "us-south"
-      TF_VAR_provider_visibility: "public"

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -67,23 +67,6 @@
               "key": "override_json_string"
             },
             {
-              "key": "provider_visibility",
-              "options": [
-                {
-                  "displayname": "private",
-                  "value": "private"
-                },
-                {
-                  "displayname": "public",
-                  "value": "public"
-                },
-                {
-                  "displayname": "public-and-private",
-                  "value": "public-and-private"
-                }
-              ]
-            },
-            {
               "custom_config": {
                 "config_constraints": {
                   "generationType": "2"
@@ -211,23 +194,6 @@
             {
               "key": "ssh_public_key",
               "required": true
-            },
-            {
-              "key": "provider_visibility",
-              "options": [
-                {
-                  "displayname": "private",
-                  "value": "private"
-                },
-                {
-                  "displayname": "public",
-                  "value": "public"
-                },
-                {
-                  "displayname": "public-and-private",
-                  "value": "public-and-private"
-                }
-              ]
             },
             {
               "hidden": true,
@@ -568,23 +534,6 @@
               "required": true
             },
             {
-              "key": "provider_visibility",
-              "options": [
-                {
-                  "displayname": "private",
-                  "value": "private"
-                },
-                {
-                  "displayname": "public",
-                  "value": "public"
-                },
-                {
-                  "displayname": "public-and-private",
-                  "value": "public-and-private"
-                }
-              ]
-            },
-            {
               "custom_config": {
                 "config_constraints": {
                   "generationType": "2"
@@ -722,23 +671,6 @@
               },
               "key": "region",
               "required": true
-            },
-            {
-              "key": "provider_visibility",
-              "options": [
-                {
-                  "displayname": "private",
-                  "value": "private"
-                },
-                {
-                  "displayname": "public",
-                  "value": "public"
-                },
-                {
-                  "displayname": "public-and-private",
-                  "value": "public-and-private"
-                }
-              ]
             },
             {
               "key": "add_edge_vpc",
@@ -1091,23 +1023,6 @@
               "key": "region",
               "required": true,
               "type": "string"
-            },
-            {
-              "key": "provider_visibility",
-              "options": [
-                {
-                  "displayname": "private",
-                  "value": "private"
-                },
-                {
-                  "displayname": "public",
-                  "value": "public"
-                },
-                {
-                  "displayname": "public-and-private",
-                  "value": "public-and-private"
-                }
-              ]
             }
           ],
           "iam_permissions": [
@@ -1226,23 +1141,6 @@
                 }
               ],
               "custom_config": {}
-            },
-            {
-              "key": "provider_visibility",
-              "options": [
-                {
-                  "displayname": "private",
-                  "value": "private"
-                },
-                {
-                  "displayname": "public",
-                  "value": "public"
-                },
-                {
-                  "displayname": "public-and-private",
-                  "value": "public-and-private"
-                }
-              ]
             },
             {
               "hidden": true,

--- a/patterns/roks-quickstart/provider.tf
+++ b/patterns/roks-quickstart/provider.tf
@@ -1,5 +1,4 @@
 provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
   region           = var.region
-  visibility       = var.provider_visibility
 }

--- a/patterns/roks-quickstart/variables.tf
+++ b/patterns/roks-quickstart/variables.tf
@@ -8,15 +8,6 @@ variable "ibmcloud_api_key" {
   sensitive   = true
 }
 
-variable "provider_visibility" {
-  description = "Set the visibility value for the IBM terraform provider. Supported values are `public`, `private`, `public-and-private`. [Learn more](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints)."
-  type        = string
-  default     = "private"
-  validation {
-    condition     = contains(["public", "private", "public-and-private"], var.provider_visibility)
-    error_message = "Invalid visibility option. Allowed values are 'public', 'private', or 'public-and-private'."
-  }
-}
 variable "prefix" {
   description = "A unique identifier for resources that is prepended to resources that are provisioned. Must begin with a lowercase letter and end with a lowercase letter or number. Must be 13 or fewer characters."
   type        = string

--- a/patterns/roks/main.tf
+++ b/patterns/roks/main.tf
@@ -6,7 +6,6 @@ provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
   region           = var.region
   ibmcloud_timeout = 60
-  visibility       = var.provider_visibility
 }
 
 ##############################################################################

--- a/patterns/roks/variables.tf
+++ b/patterns/roks/variables.tf
@@ -7,15 +7,7 @@ variable "ibmcloud_api_key" {
   type        = string
   sensitive   = true
 }
-variable "provider_visibility" {
-  description = "Set the visibility value for the IBM terraform provider. Supported values are `public`, `private`, `public-and-private`. [Learn more](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints)."
-  type        = string
-  default     = "private"
-  validation {
-    condition     = contains(["public", "private", "public-and-private"], var.provider_visibility)
-    error_message = "Invalid visibility option. Allowed values are 'public', 'private', or 'public-and-private'."
-  }
-}
+
 variable "prefix" {
   description = "A unique identifier for resources that is prepended to resources that are provisioned. Must begin with a lowercase letter and end with a lowercase letter or number. Must be 13 or fewer characters."
   type        = string

--- a/patterns/vpc/main.tf
+++ b/patterns/vpc/main.tf
@@ -6,7 +6,6 @@ provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
   region           = var.region
   ibmcloud_timeout = 60
-  visibility       = var.provider_visibility
 }
 
 ##############################################################################

--- a/patterns/vpc/variables.tf
+++ b/patterns/vpc/variables.tf
@@ -7,15 +7,7 @@ variable "ibmcloud_api_key" {
   type        = string
   sensitive   = true
 }
-variable "provider_visibility" {
-  description = "Set the visibility value for the IBM terraform provider. Supported values are `public`, `private`, `public-and-private`. [Learn more](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints)."
-  type        = string
-  default     = "private"
-  validation {
-    condition     = contains(["public", "private", "public-and-private"], var.provider_visibility)
-    error_message = "Invalid visibility option. Allowed values are 'public', 'private', or 'public-and-private'."
-  }
-}
+
 variable "prefix" {
   description = "A unique identifier for resources that is prepended to resources that are provisioned. Must begin with a lowercase letter and end with a lowercase letter or number. Must be 16 or fewer characters."
   type        = string

--- a/patterns/vsi-extension/provider.tf
+++ b/patterns/vsi-extension/provider.tf
@@ -1,5 +1,4 @@
 provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
   region           = var.region
-  visibility       = var.provider_visibility
 }

--- a/patterns/vsi-extension/variables.tf
+++ b/patterns/vsi-extension/variables.tf
@@ -3,16 +3,7 @@ variable "ibmcloud_api_key" {
   type        = string
   sensitive   = true
 }
-variable "provider_visibility" {
-  description = "Set the visibility value for the IBM terraform provider. Supported values are `public`, `private`, `public-and-private`. [Learn more](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints)."
-  type        = string
-  default     = "private"
 
-  validation {
-    condition     = contains(["public", "private", "public-and-private"], var.provider_visibility)
-    error_message = "Invalid visibility option. Allowed values are 'public', 'private', or 'public-and-private'."
-  }
-}
 variable "region" {
   description = "The region of the landing zone VPC."
   type        = string

--- a/patterns/vsi-quickstart/provider.tf
+++ b/patterns/vsi-quickstart/provider.tf
@@ -1,5 +1,4 @@
 provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
   region           = var.region
-  visibility       = var.provider_visibility
 }

--- a/patterns/vsi-quickstart/variables.tf
+++ b/patterns/vsi-quickstart/variables.tf
@@ -8,16 +8,6 @@ variable "ibmcloud_api_key" {
   sensitive   = true
 }
 
-variable "provider_visibility" {
-  description = "Set the visibility value for the IBM terraform provider. Supported values are `public`, `private`, `public-and-private`. [Learn more](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints)."
-  type        = string
-  default     = "private"
-
-  validation {
-    condition     = contains(["public", "private", "public-and-private"], var.provider_visibility)
-    error_message = "Invalid visibility option. Allowed values are 'public', 'private', or 'public-and-private'."
-  }
-}
 variable "prefix" {
   description = "A unique identifier for resources that is prepended to resources that are provisioned. Must begin with a lowercase letter and end with a lowercase letter or number. Must be 16 or fewer characters."
   type        = string

--- a/patterns/vsi/main.tf
+++ b/patterns/vsi/main.tf
@@ -6,7 +6,6 @@ provider "ibm" {
   ibmcloud_api_key = var.ibmcloud_api_key
   region           = var.region
   ibmcloud_timeout = 60
-  visibility       = var.provider_visibility
 }
 
 ##############################################################################

--- a/patterns/vsi/variables.tf
+++ b/patterns/vsi/variables.tf
@@ -7,15 +7,7 @@ variable "ibmcloud_api_key" {
   type        = string
   sensitive   = true
 }
-variable "provider_visibility" {
-  description = "Set the visibility value for the IBM terraform provider. Supported values are `public`, `private`, `public-and-private`. [Learn more](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/guides/custom-service-endpoints)."
-  type        = string
-  default     = "private"
-  validation {
-    condition     = contains(["public", "private", "public-and-private"], var.provider_visibility)
-    error_message = "Invalid visibility option. Allowed values are 'public', 'private', or 'public-and-private'."
-  }
-}
+
 variable "prefix" {
   description = "A unique identifier for resources that is prepended to resources that are provisioned. Must begin with a lowercase letter and end with a lowercase letter or number. Must be 16 or fewer characters."
   type        = string

--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -18,7 +18,6 @@ func TestRunRoksPatternWithHPCS(t *testing.T) {
 	options.TerraformVars["hs_crypto_instance_name"] = permanentResources["hpcs_name_south"]
 	options.TerraformVars["hs_crypto_resource_group"] = permanentResources["hpcs_rg_south"]
 	options.TerraformVars["skip_kms_block_storage_s2s_auth_policy"] = true
-	options.TerraformVars["provider_visibility"] = "public"
 	// If "jp-osa" was the best region selected, default to us-south instead.
 	// "jp-osa" is currently not allowing hs-crypto be used for encrypting buckets in that region.
 	currentRegion, ok := options.TerraformVars["region"]
@@ -40,7 +39,6 @@ func TestRunVSIPatternWithHPCS(t *testing.T) {
 	options.TerraformVars["hs_crypto_instance_name"] = permanentResources["hpcs_name_south"]
 	options.TerraformVars["hs_crypto_resource_group"] = permanentResources["hpcs_rg_south"]
 	options.TerraformVars["skip_kms_block_storage_s2s_auth_policy"] = true
-	options.TerraformVars["provider_visibility"] = "public"
 	// If "jp-osa" was the best region selected, default to us-south instead.
 	// "jp-osa" is currently not allowing hs-crypto be used for encrypting buckets in that region.
 	currentRegion, ok := options.TerraformVars["region"]

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -76,8 +76,7 @@ func setupOptionsQuickStartPattern(t *testing.T, prefix string, dir string) *tes
 		TerraformDir: dir,
 		Prefix:       prefix,
 		TerraformVars: map[string]interface{}{
-			"ssh_key":             sshPublicKey,
-			"provider_visibility": "public",
+			"ssh_key": sshPublicKey,
 		},
 		CloudInfoService: sharedInfoSvc,
 	})
@@ -159,8 +158,7 @@ func setupOptionsROKSQuickStartPattern(t *testing.T, prefix string, dir string) 
 		Prefix:           prefix,
 		CloudInfoService: sharedInfoSvc,
 		TerraformVars: map[string]interface{}{
-			"entitlement":         "cloud_pak",
-			"provider_visibility": "public",
+			"entitlement": "cloud_pak",
 		},
 	})
 
@@ -211,7 +209,6 @@ func setupOptionsRoksPattern(t *testing.T, prefix string) *testhelper.TestOption
 		"enable_transit_gateway":              false,
 		"use_ibm_cloud_private_api_endpoints": false,
 		"verify_cluster_network_readiness":    false,
-		"provider_visibility":                 "public",
 	}
 
 	return options
@@ -261,7 +258,6 @@ func setupOptionsVsiPattern(t *testing.T, prefix string) *testhelper.TestOptions
 		"region":                 options.Region,
 		"add_atracker_route":     add_atracker_route,
 		"enable_transit_gateway": false,
-		"provider_visibility":    "public",
 	}
 
 	return options
@@ -308,7 +304,6 @@ func setupOptionsVpcPattern(t *testing.T, prefix string) *testhelper.TestOptions
 		"region":                 options.Region,
 		"add_atracker_route":     add_atracker_route,
 		"enable_transit_gateway": false,
-		"provider_visibility":    "public",
 	}
 
 	return options
@@ -458,7 +453,6 @@ func setupOptionsVsiExtention(t *testing.T, prefix string, region string, existi
 			"boot_volume_encryption_key": keyID,
 			"vpc_id":                     managementVpcID,
 			"ssh_public_key":             sshPublicKey,
-			"provider_visibility":        "public",
 		},
 	})
 
@@ -604,7 +598,6 @@ func TestRunVsiExtention(t *testing.T) {
 		Vars: map[string]interface{}{
 			"prefix":                 prefix,
 			"region":                 region,
-			"provider_visibility":    "public",
 			"tags":                   tags,
 			"enable_transit_gateway": false,
 		},
@@ -663,10 +656,9 @@ func TestRunUpgradeVsiExtention(t *testing.T) {
 	existingTerraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
 		TerraformDir: vpcTerraformDir,
 		Vars: map[string]interface{}{
-			"prefix":              prefix,
-			"region":              region,
-			"provider_visibility": "public",
-			"tags":                tags,
+			"prefix": prefix,
+			"region": region,
+			"tags":   tags,
 		},
 		// Set Upgrade to true to ensure latest version of providers and modules are used by terratest.
 		// This is the same as setting the -upgrade=true flag with terraform.

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -559,7 +559,8 @@ func TestRunVPCPatternSchematics(t *testing.T) {
 
 	options.TerraformVars = []testschematic.TestSchematicTerraformVar{
 		{Name: "ibmcloud_api_key", Value: options.RequiredEnvironmentVars["TF_VAR_ibmcloud_api_key"], DataType: "string", Secure: true},
-		{Name: "region", Value: options.Region, DataType: "string"},
+		// Here Region is set explicitly to 'us-east' to plug the test gap as mentioned here : https://github.com/terraform-ibm-modules/terraform-ibm-landing-zone/issues/928
+		{Name: "region", Value: "us-east", DataType: "string"},
 		{Name: "prefix", Value: options.Prefix, DataType: "string"},
 		{Name: "tags", Value: options.Tags, DataType: "list(string)"},
 		{Name: "add_atracker_route", Value: add_atracker_route, DataType: "bool"},


### PR DESCRIPTION
### Description

This reverts commit a6c87a4142f275a2bbbece76bc51cdc3129a0ca9. and plugs test gaps mentioned in [issue](https://github.com/terraform-ibm-modules/terraform-ibm-landing-zone/issues/928)

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

reverts the ability to expose provider_visibility as there is a bug when setting the provider visibility to private related to resource tags and also plugs test gaps related to it

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
