### PR TITLE
fix: force vpc flow logs to wait for auth policy sleep

### DIFF
--- a/atracker.tf
+++ b/atracker.tf
@@ -31,7 +31,7 @@ resource "ibm_atracker_target" "atracker_target" {
   target_type = "cloud_object_storage"
 
   # Wait for buckets and auth policies to ensure successful provision
-  depends_on = [ibm_cos_bucket.buckets, ibm_iam_authorization_policy.policy, ibm_iam_authorization_policy.cos_bucket_policy]
+  depends_on = [ibm_cos_bucket.buckets, ibm_iam_authorization_policy.policy, time_sleep.wait_for_authorization_policy_buckets]
 }
 
 resource "ibm_atracker_route" "atracker_route" {

--- a/atracker.tf
+++ b/atracker.tf
@@ -24,14 +24,11 @@ resource "ibm_atracker_target" "atracker_target" {
   cos_endpoint {
     endpoint                   = "s3.private.${var.region}.cloud-object-storage.appdomain.cloud"
     target_crn                 = local.bucket_to_instance_map[var.atracker.collector_bucket_name].id
-    bucket                     = ibm_cos_bucket.buckets[replace(var.atracker.collector_bucket_name, var.prefix, "")].bucket_name
+    bucket                     = time_sleep.wait_for_authorization_policy_buckets[replace(var.atracker.collector_bucket_name, var.prefix, "")].triggers["bucket_name"]
     service_to_service_enabled = true
   }
   name        = "${var.prefix}-atracker"
   target_type = "cloud_object_storage"
-
-  # Wait for buckets and auth policies to ensure successful provision
-  depends_on = [ibm_cos_bucket.buckets, ibm_iam_authorization_policy.policy, time_sleep.wait_for_authorization_policy_buckets]
 }
 
 resource "ibm_atracker_route" "atracker_route" {

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ module "vpc" {
   existing_subnets                       = each.value.existing_subnets
   enable_vpc_flow_logs                   = (each.value.flow_logs_bucket_name != null) ? true : false
   create_authorization_policy_vpc_to_cos = false
-  existing_storage_bucket_name           = (each.value.flow_logs_bucket_name != null && time_sleep.wait_for_authorization_policy_buckets.id != null) ? ibm_cos_bucket.buckets[each.value.flow_logs_bucket_name].bucket_name : null
+  existing_storage_bucket_name           = (each.value.flow_logs_bucket_name != null && try(time_sleep.wait_for_authorization_policy_buckets.id, "IGNORE_ERROR") != null) ? ibm_cos_bucket.buckets[each.value.flow_logs_bucket_name].bucket_name : null
   clean_default_sg_acl                   = (each.value.clean_default_sg_acl == null) ? false : each.value.clean_default_sg_acl
   dns_binding_name                       = each.value.dns_binding_name
   dns_instance_name                      = each.value.dns_instance_name

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ module "vpc" {
   existing_subnets                       = each.value.existing_subnets
   enable_vpc_flow_logs                   = (each.value.flow_logs_bucket_name != null) ? true : false
   create_authorization_policy_vpc_to_cos = false
-  existing_storage_bucket_name           = (each.value.flow_logs_bucket_name != null && try(time_sleep.wait_for_authorization_policy_buckets.id, "IGNORE_ERROR") != null) ? ibm_cos_bucket.buckets[each.value.flow_logs_bucket_name].bucket_name : null
+  existing_storage_bucket_name           = (each.value.flow_logs_bucket_name != null) ? time_sleep.wait_for_authorization_policy_buckets[each.value.flow_logs_bucket_name].triggers["bucket_name"] : null
   clean_default_sg_acl                   = (each.value.clean_default_sg_acl == null) ? false : each.value.clean_default_sg_acl
   dns_binding_name                       = each.value.dns_binding_name
   dns_instance_name                      = each.value.dns_instance_name

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ module "vpc" {
   existing_subnets                       = each.value.existing_subnets
   enable_vpc_flow_logs                   = (each.value.flow_logs_bucket_name != null) ? true : false
   create_authorization_policy_vpc_to_cos = false
-  existing_storage_bucket_name           = (each.value.flow_logs_bucket_name != null) ? ibm_cos_bucket.buckets[each.value.flow_logs_bucket_name].bucket_name : null
+  existing_storage_bucket_name           = (each.value.flow_logs_bucket_name != null && time_sleep.wait_for_authorization_policy_buckets.id != null) ? ibm_cos_bucket.buckets[each.value.flow_logs_bucket_name].bucket_name : null
   clean_default_sg_acl                   = (each.value.clean_default_sg_acl == null) ? false : each.value.clean_default_sg_acl
   dns_binding_name                       = each.value.dns_binding_name
   dns_instance_name                      = each.value.dns_instance_name

--- a/service_authorizations.tf
+++ b/service_authorizations.tf
@@ -170,7 +170,7 @@ resource "time_sleep" "wait_for_authorization_policy" {
 
 # This time_sleep is a for_each, and will have one instance per bucket we are creating,
 # and dependent (timer start) on the bucket authorization creations.
-# The triggers serve two purposes: 
+# The triggers serve two purposes:
 #   - the create timer will be used again if the bucket itself is changed (the crn changes)
 #   - if we need to reference any bucket attributes from this sleep directly, to create implicity dependency on this wait
 resource "time_sleep" "wait_for_authorization_policy_buckets" {

--- a/service_authorizations.tf
+++ b/service_authorizations.tf
@@ -168,8 +168,19 @@ resource "time_sleep" "wait_for_authorization_policy" {
   create_duration = "30s"
 }
 
+# This time_sleep is a for_each, and will have one instance per bucket we are creating,
+# and dependent (timer start) on the bucket authorization creations.
+# The triggers serve two purposes: 
+#   - the create timer will be used again if the bucket itself is changed (the crn changes)
+#   - if we need to reference any bucket attributes from this sleep directly, to create implicity dependency on this wait
 resource "time_sleep" "wait_for_authorization_policy_buckets" {
+  for_each   = ibm_cos_bucket.buckets
   depends_on = [ibm_iam_authorization_policy.cos_bucket_policy]
+
+  triggers = {
+    bucket_name = each.value.bucket_name
+    bucket_crn  = each.value.crn
+  }
 
   create_duration = "30s"
 }


### PR DESCRIPTION
### Description

Added a reference to the `time_sleep` resource of bucket auth polices to the VPC Module input for flow log bucket, to implicitly force the flow logs to wait for all bucket auth policies to complete first.

This fixes a random timing issue in which flow logs are getting set up slightly before the auth policy for buckets are finished.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
