### PR TITLE
fix: added new base module output for cos resource key details

### DIFF
--- a/README.md
+++ b/README.md
@@ -960,6 +960,7 @@ module "cluster_pattern" {
 | <a name="output_cos_bucket_data"></a> [cos\_bucket\_data](#output\_cos\_bucket\_data) | List of data for COS buckets creaed |
 | <a name="output_cos_bucket_names"></a> [cos\_bucket\_names](#output\_cos\_bucket\_names) | List of names for COS buckets created |
 | <a name="output_cos_data"></a> [cos\_data](#output\_cos\_data) | List of Cloud Object Storage instance data |
+| <a name="output_cos_key_credentials_map"></a> [cos\_key\_credentials\_map](#output\_cos\_key\_credentials\_map) | Map of resource key credentials created for COS instances, organized by the key name supplied in the `cos.keys[]` input variable. Contains sensitive output including API keys and HMAC credentials. |
 | <a name="output_cos_key_names"></a> [cos\_key\_names](#output\_cos\_key\_names) | List of names for created COS keys |
 | <a name="output_cos_names"></a> [cos\_names](#output\_cos\_names) | List of Cloud Object Storage instance names |
 | <a name="output_f5_hosts"></a> [f5\_hosts](#output\_f5\_hosts) | List of bastion host names |

--- a/outputs.tf
+++ b/outputs.tf
@@ -147,6 +147,21 @@ output "cos_key_names" {
   ]
 }
 
+output "cos_key_credentials_map" {
+  description = "Map of resource key credentials created for COS instances, organized by the key name supplied in the `cos.keys[]` input variable. Contains sensitive output including API keys and HMAC credentials."
+  value = {
+    for k, v in ibm_resource_key.key : k => {
+      guid : v.guid
+      id : v.id
+      crn : v.crn
+      name : v.name
+      credentials : v.credentials
+      credentials_json : v.credentials_json
+    }
+  }
+  sensitive = true
+}
+
 output "cos_bucket_names" {
   description = "List of names for COS buckets created"
   value = [


### PR DESCRIPTION
### Description

Added a new output to the base module for retreiving credential details for COS if created.

The new output `cos_key_credentials_map` is a sensitive output containing all credential outputs of any resource keys created for COS instances.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
