### PR TITLE
Update .catalog-onboard-pipeline.yaml - no longer need to include git submodule

### DIFF
--- a/.catalog-onboard-pipeline.yaml
+++ b/.catalog-onboard-pipeline.yaml
@@ -5,7 +5,6 @@ offerings:
     kind: solution
     catalog_id: 7df1e4ca-d54c-4fd0-82ce-3d13247308cd
     offering_id: ef663980-4c71-4fac-af4f-4a510a9bcf68
-    include_git_submodules: true
     variations:
       - name: quickstart
         mark_ready: false
@@ -31,7 +30,6 @@ offerings:
     kind: solution
     catalog_id: 7df1e4ca-d54c-4fd0-82ce-3d13247308cd
     offering_id: 9fc0fa64-27af-4fed-9dce-47b3640ba739
-    include_git_submodules: true
     variations:
       - name: standard
         mark_ready: false
@@ -44,7 +42,6 @@ offerings:
     kind: solution
     catalog_id: 7df1e4ca-d54c-4fd0-82ce-3d13247308cd
     offering_id: 95fccffc-ae3b-42df-b6d9-80be5914d852
-    include_git_submodules: true
     variations:
       - name: standard
         mark_ready: false


### PR DESCRIPTION
### Description

No longer need to include git submodule in the tgz used by catalog import. This is only required when you have an ansible pre-/post script, but this no longer exists in any of the landing zone DAs.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
