### PR TITLE
feat: Added next step urls for landing zone VPC

### DIFF
--- a/patterns/vpc/outputs.tf
+++ b/patterns/vpc/outputs.tf
@@ -147,7 +147,7 @@ output "schematics_workspace_id" {
 ##############################################################################
 
 output "next_steps_text" {
-  value       = "Your Virtual Private Cloud are ready."
+  value       = "Your Virtual Private Clouds are ready."
   description = "Next steps text"
 }
 


### PR DESCRIPTION
### Description
* Added next step URLs in DA for landing zone VPC. 
* `next_step_primary_url` directing to the Virtual Private Clouds page.
* `next_step_secondary_url` directing to the Virtual Private Documentation page.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content
Added next step URLs in DA for landing zone VPC

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
